### PR TITLE
fix: Services.yaml // New Identifier

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -4,6 +4,9 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 from homeassistant import config_entries
 from homeassistant.const import (
@@ -122,4 +125,11 @@ async def async_unload_entry(hass, config_entry):
 
     del hass.data[DOMAIN][account]
 
+    return True
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove a config entry from a device."""
     return True

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -2,7 +2,7 @@ import logging
 from datetime import timedelta
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
@@ -32,7 +32,8 @@ from .const import (
 
 REFRESH_VEHICLE_DATA_FAILED_EVENT = "refresh_failed"
 REFRESH_VEHICLE_DATA_COMPLETED_EVENT = "refresh_completed"
-SERVICE_REFRESH_VEHICLE_DATA = "refresh_data"
+
+SERVICE_REFRESH_VEHICLE_DATA = "refresh_vehicle_data"
 SERVICE_REFRESH_VEHICLE_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_VIN): cv.string,
@@ -168,7 +169,9 @@ class AudiAccount(AudiConnectObserver):
             )
 
     async def execute_vehicle_action(self, service):
-        vin = service.data.get(CONF_VIN).lower()
+        device_id = service.data.get(CONF_VIN).lower()
+        device = dr.async_get(self.hass).async_get(device_id)
+        vin = dict(device.identifiers).get(DOMAIN)
         action = service.data.get(CONF_ACTION).lower()
 
         if action == "lock":
@@ -198,7 +201,9 @@ class AudiAccount(AudiConnectObserver):
         await self._refresh_vehicle_data(vin)
 
     async def refresh_vehicle_data(self, service):
-        vin = service.data.get(CONF_VIN).lower()
+        device_id = service.data.get(CONF_VIN).lower()
+        device = dr.async_get(self.hass).async_get(device_id)
+        vin = dict(device.identifiers).get(DOMAIN)
         await self._refresh_vehicle_data(vin)
 
     async def _refresh_vehicle_data(self, vin):

--- a/custom_components/audiconnect/audi_entity.py
+++ b/custom_components/audiconnect/audi_entity.py
@@ -52,29 +52,27 @@ class AudiEntity(Entity):
         return True
 
     @property
-    def extra_state_attributes(self):
-        """Return device specific state attributes."""
-        return dict(
-            self._instrument.attributes,
-            model="{}/{}".format(
-                self._instrument.vehicle_model, self._instrument.vehicle_name
-            ),
-            model_year=self._instrument.vehicle_model_year,
-            model_family=self._instrument.vehicle_model_family,
-            title=self._instrument.vehicle_name,
-            csid=self._instrument.vehicle_csid,
-            vin=self._instrument.vehicle_vin,
-        )
-
-    @property
     def unique_id(self):
         return self._instrument.full_name
 
     @property
     def device_info(self):
         return {
-            "identifiers": {(DOMAIN, self._instrument.vehicle_name)},
+            "identifiers": {(DOMAIN, self._instrument.vehicle_vin)},
             "manufacturer": "Audi",
-            "name": self._vehicle_name,
             "model": self._instrument.vehicle_model_family,
+            "name": self._vehicle_name,
         }
+
+    @property
+    def extra_state_attributes(self):
+        """Return device specific state attributes."""
+        return dict(
+            self._instrument.attributes,
+            model=self._instrument.vehicle_model,
+            model_year=self._instrument.vehicle_model_year,
+            model_family=self._instrument.vehicle_model_family,
+            title=self._instrument.vehicle_name,
+            csid=self._instrument.vehicle_csid,
+            vin=self._instrument.vehicle_vin,
+        )

--- a/custom_components/audiconnect/device_tracker.py
+++ b/custom_components/audiconnect/device_tracker.py
@@ -118,8 +118,9 @@ class AudiDeviceTracker(TrackerEntity):
     @property
     def device_info(self):
         return {
-            "identifiers": {(DOMAIN, self._instrument.vehicle_name)},
+            "identifiers": {(DOMAIN, self._instrument.vehicle_vin)},
             "manufacturer": "Audi",
+            "model": self._instrument.vehicle_model_family,
             "name": self._vehicle_name,
         }
 
@@ -128,9 +129,7 @@ class AudiDeviceTracker(TrackerEntity):
         """Return device specific state attributes."""
         return dict(
             self._instrument.attributes,
-            model="{}/{}".format(
-                self._instrument.vehicle_model, self._instrument.vehicle_name
-            ),
+            model=self._instrument.vehicle_model,
             model_year=self._instrument.vehicle_model_year,
             model_family=self._instrument.vehicle_model_family,
             title=self._instrument.vehicle_name,

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -1,33 +1,34 @@
 # Describes the format for available services for audiconnect
 
 refresh_vehicle_data:
-  name: Refresh vehicle data
-  description: >
-    Request an update of the state from the vehicle, as opposed to the normal
-    update mechanism, which only retrieves data from the servers.
   fields:
     vin:
-      name: VIN
-      description: >
-        The vehicle identification number (VIN) of the vehicle, 17 characters
-      example: WBANXXXXXX1234567
+      required: true
+      selector:
+        device:
+          integration: audiconnect
 
 execute_vehicle_action:
-  name: Execute Vehicle Action
-  description: >
-    Execute Vehicle actions
   fields:
     vin:
-      name: VIN
-      description: >
-        The vehicle identification number (VIN) of the vehicle, 17 characters
-      example: WBANXXXXXX1234567
+      required: true
+      selector:
+        device:
+          integration: audiconnect
     action:
-      name: Action
-      description: >
-        The action to be executed. Possible choices, depending on subscription
-        options, include 'lock', 'unlock', 'start_climatisation',
-        'stop_climatisation, 'start_charger', 'start_timed_charger',
-        'stop_charger', 'start_preheater', 'stop_preheater,
-        'start_window_heating', 'stop_window_heating'
-      example: lock
+      required: true
+      selector:
+        select:
+          translation_key: select_mode
+          options:
+            - lock
+            - unlock
+            - start_climatisation
+            - stop_climatisation
+            - start_charger
+            - start_timed_charger
+            - stop_charger
+            - start_preheater
+            - stop_preheater
+            - start_window_heating
+            - stop_window_heating

--- a/custom_components/audiconnect/translations/de.json
+++ b/custom_components/audiconnect/translations/de.json
@@ -23,5 +23,31 @@
         "title": "Audi Connect Kontoinformationen"
       }
     }
+  },
+  "services": {
+    "refresh_vehicle_data": {
+      "name": "Fahrzeugdaten aktualisieren",
+      "description": "Request an update of the state from the vehicle, as opposed to the normal update mechanism, which only retrieves data from the servers.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "Wähle dein Audi aus."
+        }
+      }
+    },
+    "execute_vehicle_action": {
+      "name": "Fahrzeugaktionen ausführen",
+      "description": "Fahrzeugaktionen ausführen",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "Wähle dein Audi aus."
+        },
+        "action": {
+          "name": "Action",
+          "description": "The action to be executed. Possible choices, depending on subscription options."
+        }
+      }
+    }
   }
 }

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -23,5 +23,48 @@
         "title": "Audi Connect Account Info"
       }
     }
+  },
+  "selector": {
+    "select_mode": {
+      "options": {
+        "lock": "Lock",
+        "unlock": "Unlock",
+        "start_climatisation": "Start Climatisation",
+        "stop_climatisation": "Stop Climatisation",
+        "start_charger": "Start Charger",
+        "start_timed_charger": "Start timed Charger",
+        "stop_charger": "Stop Charger",
+        "start_preheater": "Start Preheater",
+        "stop_preheater": "Stop Preheater",
+        "start_window_heating": "Start Window heating",
+        "stop_window_heating": "Stop Windows heating"
+      }
+    }
+  },
+  "services": {
+    "refresh_vehicle_data": {
+      "name": "Refresh vehicle data",
+      "description": "Request an update of the state from the vehicle, as opposed to the normal update mechanism, which only retrieves data from the servers.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "The vehicle identification number (VIN) of the vehicle, 17 characters."
+        }
+      }
+    },
+    "execute_vehicle_action": {
+      "name": "Execute Vehicle Action",
+      "description": "Execute Vehicle actions",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "The vehicle identification number (VIN) of the vehicle, 17 characters."
+        },
+        "action": {
+          "name": "Action",
+          "description": "The action to be executed. Possible choices, depending on subscription options."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Currently need some testing as I'm changing the identifier: 
Instead of:
"identifiers": {(DOMAIN, self._instrument.vehicle_name)},
We now use:
 "identifiers": {(DOMAIN, self._instrument.vehicle_vin)},

This makes the Services.yaml working smooth and a name can't be a unique id.

But side-effects has to be tested. I had two vehicles after the change but might be my settings related.

I thought maybe if we update the identifier but I couldn't find an easy solution for it.