### PR TITLE
chore:  auto close issues

### DIFF
--- a/.github/workflows/inactiveIssues.yml
+++ b/.github/workflows/inactiveIssues.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/stale@v9
         with:
           days-before-issue-stale: 60
-          days-before-issue-close: -1
+          days-before-issue-close: 30
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity. Are you still experiencing this issue? "
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity. Are you still experiencing this issue? "
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Auto close issues after 30 days of being tagged stale.   Also corrected message variable to align to the config.  No rush to merge this but thought I would put it in place.   It won't do anything until 30 days from first tags which started just a few days ago. 

This is long lead times on issues but gives us time to reply as well to users.