### PR TITLE
fix: update *.bff.cariad.digital endpoints for different regions

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -189,7 +189,7 @@ class AudiService:
         self._api.use_token(self._bearer_token_json)
         data = await self._api.get(
             "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/selectivestatus?jobs={jobs}".format(
-                region="emea" if self._country.upper() !="US" else "na", vin=vin.upper(), jobs=",".join(JOBS2QUERY)
+                region="emea" if self._country.upper() != "US" else "na", vin=vin.upper(), jobs=",".join(JOBS2QUERY)
             )
         )
         _LOGGER.debug(f"{DOMAIN} - Car Data: {data}")
@@ -221,7 +221,7 @@ class AudiService:
         self._api.use_token(self._bearer_token_json)
         return await self._api.get(
             "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/parkingposition".format(
-                region="emea" if self._country.upper() !="US" else "na", vin=vin.upper(),
+                region="emea" if self._country.upper() != "US" else "na", vin=vin.upper(),
             )
         )
 
@@ -858,7 +858,7 @@ class AudiService:
             self._client_id = marketcfg_json["idkClientIDAndroidLive"]
 
         self._authorizationServerBaseURLLive = (
-            "https://{region}.bff.cariad.digital/login/v1/audi".format(region="emea" if self._country.upper() !="US" else "na")
+            "https://{region}.bff.cariad.digital/login/v1/audi".format(region="emea" if self._country.upper() != "US" else "na")
         )
         if "authorizationServerBaseURLLive" in marketcfg_json:
             self._authorizationServerBaseURLLive = marketcfg_json[
@@ -875,10 +875,10 @@ class AudiService:
         authorization_endpoint = "https://identity.vwgroup.io/oidc/v1/authorize"
         if "authorization_endpoint" in openidcfg_json:
             authorization_endpoint = openidcfg_json["authorization_endpoint"]
-        self._tokenEndpoint = "https://{region}.bff.cariad.digital/login/v1/idk/token".format(region="emea" if self._country.upper() !="US" else "na")
+        self._tokenEndpoint = "https://{region}.bff.cariad.digital/login/v1/idk/token".format(region="emea" if self._country.upper() != "US" else "na")
         if "token_endpoint" in openidcfg_json:
             self._tokenEndpoint = openidcfg_json["token_endpoint"]
-        # revocation_endpoint = "https://{region}.bff.cariad.digital/login/v1/idk/revoke".format(region="emea" if self._country.upper() !="US" else "na")
+        # revocation_endpoint = "https://{region}.bff.cariad.digital/login/v1/idk/revoke".format(region="emea" if self._country.upper() != "US" else "na")
         # if "revocation_endpoint" in openidcfg_json:
         # revocation_endpoint = openidcfg_json["revocation_endpoint"]
 

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -188,8 +188,8 @@ class AudiService:
         }
         self._api.use_token(self._bearer_token_json)
         data = await self._api.get(
-            "https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/selectivestatus?jobs={jobs}".format(
-                vin=vin.upper(), jobs=",".join(JOBS2QUERY)
+            "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/selectivestatus?jobs={jobs}".format(
+                region="emea" if self._country.upper() !="US" else "na", vin=vin.upper(), jobs=",".join(JOBS2QUERY)
             )
         )
         _LOGGER.debug(f"{DOMAIN} - Car Data: {data}")
@@ -220,8 +220,8 @@ class AudiService:
     async def get_stored_position(self, vin: str):
         self._api.use_token(self._bearer_token_json)
         return await self._api.get(
-            "https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/parkingposition".format(
-                vin=vin.upper(),
+            "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/parkingposition".format(
+                region="emea" if self._country.upper() !="US" else "na", vin=vin.upper(),
             )
         )
 
@@ -858,7 +858,7 @@ class AudiService:
             self._client_id = marketcfg_json["idkClientIDAndroidLive"]
 
         self._authorizationServerBaseURLLive = (
-            "https://emea.bff.cariad.digital/login/v1/audi"
+            "https://{region}.bff.cariad.digital/login/v1/audi".format(region="emea" if self._country.upper() !="US" else "na")
         )
         if "authorizationServerBaseURLLive" in marketcfg_json:
             self._authorizationServerBaseURLLive = marketcfg_json[
@@ -875,10 +875,10 @@ class AudiService:
         authorization_endpoint = "https://identity.vwgroup.io/oidc/v1/authorize"
         if "authorization_endpoint" in openidcfg_json:
             authorization_endpoint = openidcfg_json["authorization_endpoint"]
-        self._tokenEndpoint = "https://emea.bff.cariad.digital/login/v1/idk/token"
+        self._tokenEndpoint = "https://{region}.bff.cariad.digital/login/v1/idk/token".format(region="emea" if self._country.upper() !="US" else "na")
         if "token_endpoint" in openidcfg_json:
             self._tokenEndpoint = openidcfg_json["token_endpoint"]
-        # revocation_endpoint = "https://emea.bff.cariad.digital/login/v1/idk/revoke"
+        # revocation_endpoint = "https://{region}.bff.cariad.digital/login/v1/idk/revoke".format(region="emea" if self._country.upper() !="US" else "na")
         # if "revocation_endpoint" in openidcfg_json:
         # revocation_endpoint = openidcfg_json["revocation_endpoint"]
 

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -189,7 +189,9 @@ class AudiService:
         self._api.use_token(self._bearer_token_json)
         data = await self._api.get(
             "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/selectivestatus?jobs={jobs}".format(
-                region="emea" if self._country.upper() != "US" else "na", vin=vin.upper(), jobs=",".join(JOBS2QUERY)
+                region="emea" if self._country.upper() != "US" else "na",
+                vin=vin.upper(),
+                jobs=",".join(JOBS2QUERY),
             )
         )
         _LOGGER.debug(f"{DOMAIN} - Car Data: {data}")
@@ -221,7 +223,8 @@ class AudiService:
         self._api.use_token(self._bearer_token_json)
         return await self._api.get(
             "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/parkingposition".format(
-                region="emea" if self._country.upper() != "US" else "na", vin=vin.upper(),
+                region="emea" if self._country.upper() != "US" else "na",
+                vin=vin.upper(),
             )
         )
 
@@ -858,7 +861,9 @@ class AudiService:
             self._client_id = marketcfg_json["idkClientIDAndroidLive"]
 
         self._authorizationServerBaseURLLive = (
-            "https://{region}.bff.cariad.digital/login/v1/audi".format(region="emea" if self._country.upper() != "US" else "na")
+            "https://{region}.bff.cariad.digital/login/v1/audi".format(
+                region="emea" if self._country.upper() != "US" else "na"
+            )
         )
         if "authorizationServerBaseURLLive" in marketcfg_json:
             self._authorizationServerBaseURLLive = marketcfg_json[
@@ -875,7 +880,11 @@ class AudiService:
         authorization_endpoint = "https://identity.vwgroup.io/oidc/v1/authorize"
         if "authorization_endpoint" in openidcfg_json:
             authorization_endpoint = openidcfg_json["authorization_endpoint"]
-        self._tokenEndpoint = "https://{region}.bff.cariad.digital/login/v1/idk/token".format(region="emea" if self._country.upper() != "US" else "na")
+        self._tokenEndpoint = (
+            "https://{region}.bff.cariad.digital/login/v1/idk/token".format(
+                region="emea" if self._country.upper() != "US" else "na"
+            )
+        )
         if "token_endpoint" in openidcfg_json:
             self._tokenEndpoint = openidcfg_json["token_endpoint"]
         # revocation_endpoint = "https://{region}.bff.cariad.digital/login/v1/idk/revoke".format(region="emea" if self._country.upper() != "US" else "na")


### PR DESCRIPTION
At least for me in the US, I have to use the `na` endpoint. Found this by proxying my app and seeing this instead. Previously I was getting 401 unauthorized in my logs and essentially no data back.


Confirmed I'm now getting all expected entities:
![image](https://github.com/audiconnect/audi_connect_ha/assets/12614518/3c42e536-d7d5-4d72-8a5a-ff74582f7c02)
