### PR TITLE
feat: New Service Call - Update All Vehicles Data

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -23,6 +23,13 @@ from .const import (
     DOMAIN,
     CONF_VIN,
     CONF_ACTION,
+    CONF_CLIMATE_TEMP_F,
+    CONF_CLIMATE_TEMP_C,
+    CONF_CLIMATE_GLASS,
+    CONF_CLIMATE_SEAT_FL,
+    CONF_CLIMATE_SEAT_FR,
+    CONF_CLIMATE_SEAT_RL,
+    CONF_CLIMATE_SEAT_RR,
     CONF_REGION,
     CONF_SPIN,
     SIGNAL_STATE_UPDATED,
@@ -42,6 +49,20 @@ SERVICE_REFRESH_VEHICLE_DATA_SCHEMA = vol.Schema(
 SERVICE_EXECUTE_VEHICLE_ACTION = "execute_vehicle_action"
 SERVICE_EXECUTE_VEHICLE_ACTION_SCHEMA = vol.Schema(
     {vol.Required(CONF_VIN): cv.string, vol.Required(CONF_ACTION): cv.string}
+)
+
+SERVICE_START_CLIMATE_CONTROL = "start_climate_control"
+SERVICE_START_CLIMATE_CONTROL_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_VIN): cv.string,
+        vol.Optional(CONF_CLIMATE_TEMP_F): cv.positive_int,
+        vol.Optional(CONF_CLIMATE_TEMP_C): cv.positive_int,
+        vol.Optional(CONF_CLIMATE_GLASS): cv.boolean,
+        vol.Optional(CONF_CLIMATE_SEAT_FL): cv.boolean,
+        vol.Optional(CONF_CLIMATE_SEAT_FR): cv.boolean,
+        vol.Optional(CONF_CLIMATE_SEAT_RL): cv.boolean,
+        vol.Optional(CONF_CLIMATE_SEAT_RR): cv.boolean,
+    }
 )
 
 SERVICE_UPDATE_ALL_VEHICLES_DATA = "update_all_vehicles_data"
@@ -68,6 +89,7 @@ class AudiAccount(AudiConnectObserver):
             country=self.config_entry.data.get(CONF_REGION),
             spin=self.config_entry.data.get(CONF_SPIN),
         )
+
         self.hass.services.async_register(
             DOMAIN,
             SERVICE_REFRESH_VEHICLE_DATA,
@@ -79,6 +101,12 @@ class AudiAccount(AudiConnectObserver):
             SERVICE_EXECUTE_VEHICLE_ACTION,
             self.execute_vehicle_action,
             schema=SERVICE_EXECUTE_VEHICLE_ACTION_SCHEMA,
+        )
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_START_CLIMATE_CONTROL,
+            self.start_climate_control,
+            schema=SERVICE_START_CLIMATE_CONTROL_SCHEMA,
         )
         self.hass.services.async_register(
             DOMAIN,
@@ -199,6 +227,28 @@ class AudiAccount(AudiConnectObserver):
             await self.connection.set_vehicle_window_heating(vin, True)
         if action == "stop_window_heating":
             await self.connection.set_vehicle_window_heating(vin, False)
+
+    async def start_climate_control(self, service):
+        vin = service.data.get(CONF_VIN).lower()
+        # Optional Parameters
+        temp_f = service.data.get(CONF_CLIMATE_TEMP_F, None)
+        temp_c = service.data.get(CONF_CLIMATE_TEMP_C, None)
+        glass_heating = service.data.get(CONF_CLIMATE_GLASS, False)
+        seat_fl = service.data.get(CONF_CLIMATE_SEAT_FL, False)
+        seat_fr = service.data.get(CONF_CLIMATE_SEAT_FR, False)
+        seat_rl = service.data.get(CONF_CLIMATE_SEAT_RL, False)
+        seat_rr = service.data.get(CONF_CLIMATE_SEAT_RR, False)
+
+        await self.connection.start_climate_control(
+            vin,
+            temp_f,
+            temp_c,
+            glass_heating,
+            seat_fl,
+            seat_fr,
+            seat_rl,
+            seat_rr,
+        )
 
     async def handle_notification(self, vin: str, action: str) -> None:
         await self._refresh_vehicle_data(vin)

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -44,6 +44,8 @@ SERVICE_EXECUTE_VEHICLE_ACTION_SCHEMA = vol.Schema(
     {vol.Required(CONF_VIN): cv.string, vol.Required(CONF_ACTION): cv.string}
 )
 
+SERVICE_UPDATE_ALL_VEHICLES_DATA = "update_all_vehicles_data"
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -66,7 +68,6 @@ class AudiAccount(AudiConnectObserver):
             country=self.config_entry.data.get(CONF_REGION),
             spin=self.config_entry.data.get(CONF_SPIN),
         )
-
         self.hass.services.async_register(
             DOMAIN,
             SERVICE_REFRESH_VEHICLE_DATA,
@@ -78,6 +79,11 @@ class AudiAccount(AudiConnectObserver):
             SERVICE_EXECUTE_VEHICLE_ACTION,
             self.execute_vehicle_action,
             schema=SERVICE_EXECUTE_VEHICLE_ACTION_SCHEMA,
+        )
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_UPDATE_ALL_VEHICLES_DATA,
+            self.update,
         )
 
         self.connection.add_observer(self)

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -237,6 +237,52 @@ class AudiConnectAccount:
                 ),
             )
 
+    async def start_climate_control(
+        self,
+        vin: str,
+        temp_f: int,
+        temp_c: int,
+        glass_heating: bool,
+        seat_fl: bool,
+        seat_fr: bool,
+        seat_rl: bool,
+        seat_rr: bool,
+    ):
+        if not self._loggedin:
+            await self.login()
+
+        if not self._loggedin:
+            return False
+
+        try:
+            _LOGGER.debug(
+                f"Sending command to start climate control for vehicle {vin} with settings - Temp(F): {temp_f}, Temp(C): {temp_c}, Glass Heating: {glass_heating}, Seat FL: {seat_fl}, Seat FR: {seat_fr}, Seat RL: {seat_rl}, Seat RR: {seat_rr}"
+            )
+
+            await self._audi_service.start_climate_control(
+                vin,
+                temp_f,
+                temp_c,
+                glass_heating,
+                seat_fl,
+                seat_fr,
+                seat_rl,
+                seat_rr,
+            )
+
+            _LOGGER.debug(f"Successfully started climate control of vehicle {vin}")
+
+            await self.notify(vin, ACTION_CLIMATISATION)
+
+            return True
+
+        except Exception as exception:
+            _LOGGER.error(
+                f"Unable to start climate control of vehicle {vin}. Error: {exception}",
+                exc_info=True,
+            )
+            return False
+
     async def set_battery_charger(self, vin: str, activate: bool, timer: bool):
         if not self._loggedin:
             await self.login()

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -3,6 +3,13 @@ DOMAIN = "audiconnect"
 CONF_VIN = "vin"
 CONF_CARNAME = "carname"
 CONF_ACTION = "action"
+CONF_CLIMATE_TEMP_F = "temp_f"
+CONF_CLIMATE_TEMP_C = "temp_c"
+CONF_CLIMATE_GLASS = "glass_heating"
+CONF_CLIMATE_SEAT_FL = "seat_fl"
+CONF_CLIMATE_SEAT_FR = "seat_fr"
+CONF_CLIMATE_SEAT_RL = "seat_rl"
+CONF_CLIMATE_SEAT_RR = "seat_rr"
 
 MIN_UPDATE_INTERVAL = 15
 DEFAULT_UPDATE_INTERVAL = 15

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -31,3 +31,16 @@ execute_vehicle_action:
         'stop_charger', 'start_preheater', 'stop_preheater,
         'start_window_heating', 'stop_window_heating'
       example: lock
+
+update_all_vehicles_data:
+  name: Update All Vehicles Data
+  description: >
+    Updates vehicle data, for all vehicles, from the online source 
+    without forcing a vehicle refresh. If the vehicle has not
+    recently updated its data, the information retrieved may still
+    be outdated. Vehicle data typically refreshes after receiving
+    a command, such as starting climate control. It's recommended
+    to wait approximately 30 seconds between initiating a command
+    and using this service call to ensure updated data is fetched.
+    This is essentially the same function as restarting the
+    integration.

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -138,7 +138,7 @@ start_climate_control:
 update_all_vehicles_data:
   name: Update All Vehicles Data
   description: >
-    Updates vehicle data, for all vehicles, from the online source 
+    Updates vehicle data, for all vehicles, from the online source
     without forcing a vehicle refresh. If the vehicle has not
     recently updated its data, the information retrieved may still
     be outdated. Vehicle data typically refreshes after receiving

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -1,41 +1,144 @@
 # Describes the format for available services for audiconnect
-
-refresh_vehicle_data:
-  name: Refresh vehicle data
+---
+refresh_data:
+  name: Refresh Vehicle Data
   description: >
     Request an update of the state from the vehicle, as opposed to the normal
     update mechanism, which only retrieves data from the servers.
   fields:
     vin:
+      required: true
       name: VIN
       description: >
-        The vehicle identification number (VIN) of the vehicle, 17 characters
-      example: WBANXXXXXX1234567
+        The Vehicle Identification Number (VIN) of the Audi vehicle.
+        This should be a 17-character identifier unique to each vehicle.
+      example: "WAUZZZ4G7EN123456"
+      selector:
+        text:
 
 execute_vehicle_action:
   name: Execute Vehicle Action
   description: >
-    Execute Vehicle actions
+    Perform various actions on the vehicle.
   fields:
     vin:
+      required: true
       name: VIN
       description: >
-        The vehicle identification number (VIN) of the vehicle, 17 characters
-      example: WBANXXXXXX1234567
+        The Vehicle Identification Number (VIN) of the Audi vehicle.
+        This should be a 17-character identifier unique to each vehicle.
+      example: "WAUZZZ4G7EN123456"
+      selector:
+        text:
     action:
+      required: true
       name: Action
       description: >
-        The action to be executed. Possible choices, depending on subscription
-        options, include 'lock', 'unlock', 'start_climatisation',
-        'stop_climatisation, 'start_charger', 'start_timed_charger',
-        'stop_charger', 'start_preheater', 'stop_preheater,
-        'start_window_heating', 'stop_window_heating'
-      example: lock
+        The specific action to perform on the vehicle.
+        Note that available actions may vary based on the vehicle.
+      example: "lock"
+      selector:
+        select:
+          options:
+            - label: Lock
+              value: lock
+            - label: Unlock
+              value: unlock
+            - label: Start Climatisation (Legacy)
+              value: start_climatisation
+            - label: Stop Climatisation
+              value: stop_climatisation
+            - label: Start Charger
+              value: start_charger
+            - label: Start Timed Charger
+              value: start_timed_charger
+            - label: Stop Charger
+              value: stop_charger
+            - label: Start Preheater
+              value: start_preheater
+            - label: Stop Preheater
+              value: stop_preheater
+            - label: Start Window Heating
+              value: start_window_heating
+            - label: Stop Window Heating
+              value: stop_window_heating
+
+start_climate_control:
+  name: Start Climate Control
+  description: >
+    Start the climate control with options for temperature,
+    glass surface heating, and auto seat comfort.
+  fields:
+    vin:
+      required: true
+      name: VIN
+      description: >
+        The Vehicle Identification Number (VIN) of the Audi vehicle.
+        This should be a 17-character identifier unique to each vehicle.
+      example: "WAUZZZ4G7EN123456"
+      selector:
+        text:
+    temp_f:
+      name: Target Temperature (Fahrenheit)
+      description: >
+        (Optional) For 'start_climatisation':
+        Set temperature in °F. Defaults to 70°F if not provided.
+        Overrides 'temp_c'.
+      selector:
+        number:
+          min: 60
+          max: 80
+    temp_c:
+      name: Target Temperature (Celsius)
+      description: >
+        (Optional) For 'start_climatisation':
+        Set temperature in °C. Defaults to 21°C if not provided.
+        Overridden if 'temp_f' is provided.
+      selector:
+        number:
+          min: 15
+          max: 27
+    glass_heating:
+      name: Glass Surface Heating
+      description: >
+        (Optional) For 'start_climatisation':
+        Enable or disable glass heating.
+        Setting this to True activates glass heating.
+      selector:
+        boolean:
+    seat_fl:
+      name: "Auto Seat Comfort: Front-Left"
+      description: >
+        (Optional) For 'start_climatisation':
+        Enable or disable Auto Seat Comfort for the front-left seat.
+      selector:
+        boolean:
+    seat_fr:
+      name: "Auto Seat Comfort: Front-Right"
+      description: >
+        (Optional) For 'start_climatisation':
+        Enable or disable Auto Seat Comfort for the front-right seat.
+      selector:
+        boolean:
+    seat_rl:
+      name: "Auto Seat Comfort: Rear-Left"
+      description: >
+        (Optional) For 'start_climatisation':
+        Enable or disable Auto Seat Comfort for the rear-left seat.
+      selector:
+        boolean:
+    seat_rr:
+      name: "Auto Seat Comfort: Rear-Right"
+      description: >
+        (Optional) For 'start_climatisation':
+        Enable or disable Auto Seat Comfort for the rear-right seat.
+      selector:
+        boolean:
 
 update_all_vehicles_data:
   name: Update All Vehicles Data
   description: >
-    Updates vehicle data, for all vehicles, from the online source
+    Updates vehicle data, for all vehicles, from the online source 
     without forcing a vehicle refresh. If the vehicle has not
     recently updated its data, the information retrieved may still
     be outdated. Vehicle data typically refreshes after receiving

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -35,7 +35,7 @@ execute_vehicle_action:
 update_all_vehicles_data:
   name: Update All Vehicles Data
   description: >
-    Updates vehicle data, for all vehicles, from the online source 
+    Updates vehicle data, for all vehicles, from the online source
     without forcing a vehicle refresh. If the vehicle has not
     recently updated its data, the information retrieved may still
     be outdated. Vehicle data typically refreshes after receiving

--- a/readme.md
+++ b/readme.md
@@ -70,33 +70,95 @@ To add the integration, go to **Settings ➤ Devices & Services ➤ Integrations
 
 **scan_interval**
 
-- (number)(Optional) The frequency in minutes for how often to fetch status data from Audi Connect. (Optional. Default is 15 minutes, can be no more frequent than 15 min.)
+- (number)(Optional) The frequency in minutes for how often to fetch status data from Audi Connect. (Optional. Default is 15 minutes, can be no more frequent than 15 minutes.)
 
 ## Services
 
-**audiconnect.refresh_vehicle_data**
+### Audi Connect: Refresh Vehicle Data
+
+`audiconnect.refresh_data`
 
 Normal updates retrieve data from the Audi Connect service, and don't interact directly with the vehicle. _This_ service triggers an update request from the vehicle itself. When data is retrieved successfully, Home Assistant is automatically updated. The service requires a vehicle identification number (VIN) as a parameter.
 
-**audiconnect.execute_vehicle_action**
+#### Service Parameters
 
-Perform an action on the vehicle. The service takes a VIN and the action to perform as parameters. Possible action values:
+- **`vin`**: The Vehicle Identification Number (VIN) of the Audi you want to control.
 
-- lock
-- unlock
-- start_climatisation
-- stop_climatisation
-- start_charger
-- start_timed_charger
-- stop_charger
-- start_preheater
-- stop_preheater
-- start_window_heating
-- stop_window_heating
+### Audi Connect: Execute Vehicle Action
 
-**Note:** Certain action require the S-PIN to be set in the configuration.
+`audiconnect.execute_vehicle_action`
 
-When an action is successfully performed, an update request is automatically triggered.
+This service allows you to perform actions on your Audi vehicle, specified by the vehicle identification number (VIN) and the desired action.
+
+#### Service Parameters
+
+- **`vin`**: The Vehicle Identification Number (VIN) of the Audi you want to control.
+- **`action`**: The specific action to perform on the vehicle. Available actions include:
+  - **`lock`**: Lock the vehicle.
+  - **`unlock`**: Unlock the vehicle.
+  - **`start_climatisation`**: Start the vehicle's climatisation system. (Legacy)
+  - **`stop_climatisation`**: Stop the vehicle's climatisation system.
+  - **`start_charger`**: Start charging the vehicle.
+  - **`start_timed_charger`**: Start the vehicle's charger with a timer.
+  - **`stop_charger`**: Stop charging the vehicle.
+  - **`start_preheater`**: Start the vehicle's preheater system.
+  - **`stop_preheater`**: Stop the vehicle's preheater system.
+  - **`start_window_heating`**: Start heating the vehicle's windows.
+  - **`stop_window_heating`**: Stop heating the vehicle's windows.
+
+#### Usage Example
+
+To initiate the lock action for a vehicle with VIN `WAUZZZ4G7EN123456`, use the following service call:
+
+```yaml
+service: audiconnect.execute_vehicle_action
+data:
+  vin: "WAUZZZ4G7EN123456"
+  action: "lock"
+```
+
+#### Notes
+
+- Certain action require the S-PIN to be set in the configuration.
+- When an action is successfully performed, an update request is automatically triggered.
+
+### Audi Connect: Start Climate Control
+
+`audiconnect.start_climate_control`
+
+This service allows you to start the climate control with options for temperature, glass surface heating, and auto seat comfort.
+
+#### Service Parameters
+
+- **`vin`**: The Vehicle Identification Number (VIN) of the Audi you want to control.
+- **`temp_f`** (_optional_): Desired temperature in Fahrenheit. Default is `70`.
+- **`temp_c`** (_optional_): Desired temperature in Celsius. Default is `21`.
+- **`glass_heating`** (_optional_): Enable (`True`) or disable (`False`) glass heating. Default is `False`.
+- **`seat_fl`** (_optional_): Enable (`True`) or disable (`False`) the front-left seat heater. Default is `False`.
+- **`seat_fr`** (_optional_): Enable (`True`) or disable (`False`) the front-right seat heater. Default is `False`.
+- **`seat_rl`** (_optional_): Enable (`True`) or disable (`False`) the rear-left seat heater. Default is `False`.
+- **`seat_rr`** (_optional_): Enable (`True`) or disable (`False`) the rear-right seat heater. Default is `False`.
+
+#### Usage Example
+
+To start the climate control for a vehicle with VIN `WAUZZZ4G7EN123456` with a temperature of 72°F, enable glass heating, and activate both front seat heaters, use the following service call:
+
+```yaml
+service: audiconnect.start_climate_control
+data:
+  vin: "WAUZZZ4G7EN123456"
+  temp_f: 72
+  glass_heating: True
+  seat_fl: True
+  seat_fr: True
+```
+
+#### Notes
+
+- The `temp_f` and `temp_c` parameters are mutually exclusive. If both are provided, `temp_f` takes precedence.
+- If neither `temp_f` nor `temp_c` is provided, the system defaults to 70°F or 21°C.
+- Certain action require the S-PIN to be set in the configuration.
+- When an action is successfully performed, an update request is automatically triggered.
 
 ## Example Dashboard Card
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,20 @@ Normal updates retrieve data from the Audi Connect service, and don't interact d
 
 - **`vin`**: The Vehicle Identification Number (VIN) of the Audi you want to control.
 
+### Audi Connect: Update All Vehicles Data
+
+`audiconnect.update_all_vehicles_data`
+
+_This_ service triggers an update request from the cloud.
+- Functionality: Updates data for all vehicles from the online source, mirroring the action performed at integration startup or during scheduled refresh intervals.
+- Behavior: Does not force a vehicle-side data refresh. Consequently, if vehicles haven't recently pushed updates, retrieved data might be outdated.
+- Recommended Usage: Ideal for post-command updates (e.g., after initiating climate control). To ensure data accuracy, a delay of approximately 30 seconds is recommended between command issuance and this service call.
+- Note: This service essentially replicates the function of restarting the integration, offering a more granular control over data refresh moments.
+
+#### Service Parameters
+
+- `none`
+
 ### Audi Connect: Execute Vehicle Action
 
 `audiconnect.execute_vehicle_action`

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Normal updates retrieve data from the Audi Connect service, and don't interact d
 `audiconnect.update_all_vehicles_data`
 
 _This_ service triggers an update request from the cloud.
+
 - Functionality: Updates data for all vehicles from the online source, mirroring the action performed at integration startup or during scheduled refresh intervals.
 - Behavior: Does not force a vehicle-side data refresh. Consequently, if vehicles haven't recently pushed updates, retrieved data might be outdated.
 - Recommended Usage: Ideal for post-command updates (e.g., after initiating climate control). To ensure data accuracy, a delay of approximately 30 seconds is recommended between command issuance and this service call.


### PR DESCRIPTION
## `audiconnect.update_all_vehicles_data` 

### Overview:
This pull request introduces the `audiconnect.update_all_vehicles_data` service call. The service leverages an existing backend function, now made accessible through the Home Assistant UI. It's designed to update vehicle data from an online source for all vehicles linked to an account without initiating a vehicle-side refresh.

### Use Case:
Given some limitations with the "Refresh Vehicle Data" functionality, this service call provides a workaround by allowing users to manually trigger data updates. It's particularly useful for users who prefer to extend the default refresh interval significantly and wish to manually request updates at specific moments, such as after starting climate control or during periods of inactivity.

### Service Call Description:

- Functionality: Updates data for all vehicles from the online source, mirroring the action performed at integration startup or during scheduled refresh intervals.
- Behavior: Does not force a vehicle-side data refresh. Consequently, if vehicles haven't recently pushed updates, retrieved data might be outdated.
- Recommended Usage: Ideal for post-command updates (e.g., after initiating climate control). To ensure data accuracy, a delay of approximately 30 seconds is recommended between command issuance and this service call.
- Note: This service essentially replicates the function of restarting the integration, offering a more granular control over data refresh moments.

This addition aims to enhance user control over data updates, addressing specific scenarios where updated information is crucial without unnecessarily frequent automated refreshes.