### PR TITLE
feat: Refresh Interval Options

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -2,8 +2,10 @@
 
 from datetime import timedelta
 import voluptuous as vol
+import logging
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.dt import utcnow
 from homeassistant import config_entries
 from homeassistant.const import (
@@ -29,6 +31,8 @@ from .const import (
     RESOURCES,
     COMPONENTS,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -93,6 +97,12 @@ async def async_setup_entry(hass, config_entry):
     """Set up the Audi Connect component."""
     hass.data[DOMAIN]["devices"] = set()
 
+    # Attempt to retrieve the scan interval from options, then fall back to data, or use default
+    scan_interval = timedelta(minutes=config_entry.options.get(
+        CONF_SCAN_INTERVAL,
+        config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+    ))
+
     account = config_entry.data.get(CONF_USERNAME)
 
     unit_system = "metric"
@@ -107,6 +117,15 @@ async def async_setup_entry(hass, config_entry):
     else:
         data = hass.data[DOMAIN][account]
 
+    async def update_data(now):
+        """Update the data with the latest information."""
+        _LOGGER.info("Running cloud update at set interval...")
+        await data.update(utcnow())
+
+    _LOGGER.info("Scheduling update at every %s interval", scan_interval)
+    async_track_time_interval(hass, update_data, scan_interval)
+
+    # Initially update the data
     return await data.update(utcnow())
 
 

--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -98,10 +98,12 @@ async def async_setup_entry(hass, config_entry):
     hass.data[DOMAIN]["devices"] = set()
 
     # Attempt to retrieve the scan interval from options, then fall back to data, or use default
-    scan_interval = timedelta(minutes=config_entry.options.get(
-        CONF_SCAN_INTERVAL,
-        config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
-    ))
+    scan_interval = timedelta(
+        minutes=config_entry.options.get(
+            CONF_SCAN_INTERVAL,
+            config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        )
+    )
 
     account = config_entry.data.get(CONF_USERNAME)
 

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -146,3 +146,38 @@ class AudiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_SCAN_INTERVAL: scan_interval,
             },
         )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    def __init__(self, config_entry):
+        self.config_entry: config_entries.ConfigEntry = config_entry
+        _LOGGER.debug("Initializing options flow for %s", config_entry.title)
+
+    async def async_step_init(self, user_input=None):
+        _LOGGER.debug("Options flow initiated")
+        if user_input is not None:
+            _LOGGER.debug("Received user input for options: %s", user_input)
+            return self.async_create_entry(title="", data=user_input)
+
+        current_scan_interval = self.config_entry.options.get(
+            CONF_SCAN_INTERVAL,
+            self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        )
+        _LOGGER.debug("Current scan interval: %s minutes", current_scan_interval)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL, default=current_scan_interval
+                    ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_UPDATE_INTERVAL)),
+                }
+            ),
+        )

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -24,6 +24,19 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Scan Interval"
+        },
+        "title": "Audi Connect Options",
+        "data_description": {
+          "scan_interval": "(Minutes) Restart required for new scan interval to take effect."
+        }
+      }
+    }
+  },
   "selector": {
     "vehicle_actions": {
       "options": {

--- a/custom_components/audiconnect/translations/de.json
+++ b/custom_components/audiconnect/translations/de.json
@@ -24,6 +24,19 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Abfrageintervall"
+        },
+        "title": "Audi Connect-Optionen",
+        "data_description": {
+          "scan_interval": "(Minuten) Damit das neue Scanintervall wirksam wird, ist ein Neustart erforderlich."
+        }
+      }
+    }
+  },
   "selector": {
     "vehicle_actions": {
       "options": {

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -24,6 +24,19 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Scan Interval"
+        },
+        "title": "Audi Connect Options",
+        "data_description": {
+          "scan_interval": "(Minutes) Restart required for new scan interval to take effect."
+        }
+      }
+    }
+  },
   "selector": {
     "vehicle_actions": {
       "options": {

--- a/custom_components/audiconnect/translations/nb.json
+++ b/custom_components/audiconnect/translations/nb.json
@@ -23,5 +23,18 @@
         "title": "Audi Connect kontoinformasjon"
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Skanneintervall"
+        },
+        "title": "Audi Connect-alternativer",
+        "data_description": {
+          "scan_interval": "(Minutter) Omstart kreves for at nytt skanneintervall skal tre i kraft."
+        }
+      }
+    }
   }
 }

--- a/custom_components/audiconnect/translations/nl.json
+++ b/custom_components/audiconnect/translations/nl.json
@@ -23,5 +23,18 @@
         "title": "Audi Connect accountgegevens"
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Scaninterval"
+        },
+        "title": "Audi Connect-opties",
+        "data_description": {
+          "scan_interval": "(Minuten) Opnieuw opstarten vereist om het nieuwe scaninterval van kracht te laten worden."
+        }
+      }
+    }
   }
 }

--- a/custom_components/audiconnect/translations/pt-BR.json
+++ b/custom_components/audiconnect/translations/pt-BR.json
@@ -23,5 +23,18 @@
         "title": "Informações da conta Audi Connect "
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Intervalo de escaneamento"
+        },
+        "title": "Opções Audi Connect",
+        "data_description": {
+          "scan_interval": "(Minutos) É necessário reiniciar para que o novo intervalo de verificação entre em vigor."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Overview

This update introduces several enhancements and fixes aimed at improving the integration's configuration flexibility and efficiency in polling mechanisms.

### Enhancements
- **Configurable Scan Interval**: Integration of `OptionsFlowHandler` allows users to adjust the scan interval via the `Configure` menu, enhancing user control.
- **Efficient Polling**: Adoption of `async_track_time_interval` for polling initiation at startup removes the need for manual scheduling in `AudiAccount.update`, streamlining the update process.
- **Localization Updates**: Made updates to strings and translations to ensure clarity and accessibility.

### Technical Notes
- **Restart Requirement**: Changes necessitate a system restart to take effect. This requirement is detailed in the `data_description` within translations, ensuring users are informed via the UI.
- **Polling Mechanism Overhaul**: Leveraging `async_track_time_interval` from the get-go allows for interval-based polling using Home Assistant's built-in scheduling tools, bypassing the need for hardcoded scheduling.
- **Future-Proofing `AudiAccount.update`**: With these changes, `AudiAccount.update` is now freed up for potential use in front-end service calls, with plans for a follow-up PR pending this update's approval and merge.
- **Effort Towards User-Controlled Polling**: Next steps involve utilizing the `coordinator` for more flexible update scheduling, aiming to give users the ability to toggle polling on and off directly from the UI.
