### PR TITLE
feat: New Service - Refresh Cloud Data

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -63,6 +63,8 @@ SERVICE_START_CLIMATE_CONTROL_SCHEMA = vol.Schema(
     }
 )
 
+SERVICE_REFRESH_CLOUD_DATA = "refresh_cloud_data"
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -102,6 +104,11 @@ class AudiAccount(AudiConnectObserver):
             SERVICE_START_CLIMATE_CONTROL,
             self.start_climate_control,
             schema=SERVICE_START_CLIMATE_CONTROL_SCHEMA,
+        )
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_REFRESH_CLOUD_DATA,
+            self.update,
         )
 
         self.connection.add_observer(self)

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -117,6 +117,10 @@
           "description": "(Optional) Enable or disable Auto Seat Comfort for the rear-right seat."
         }
       }
+    },
+    "refresh_cloud_data": {
+      "name": "Refresh Cloud Data",
+      "description": "Retrieves current cloud data without triggering a vehicle refresh. Data may be outdated if the vehicle has not checked in recently. For best results, use 30 seconds after a command."
     }
   }
 }

--- a/custom_components/audiconnect/translations/de.json
+++ b/custom_components/audiconnect/translations/de.json
@@ -117,6 +117,10 @@
           "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort für den rechten Rücksitz."
         }
       }
+    },
+    "refresh_cloud_data": {
+      "name": "Cloud-Daten aktualisieren",
+      "description": "Ruft aktuelle Cloud-Daten ab, ohne eine Fahrzeugaktualisierung auszulösen. Die Daten sind möglicherweise veraltet, wenn das Fahrzeug nicht kürzlich eingecheckt wurde. Die besten Ergebnisse erzielen Sie, wenn Sie 30 Sekunden nach einem Befehl verwenden."
     }
   }
 }

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -117,6 +117,10 @@
           "description": "(Optional) Enable or disable Auto Seat Comfort for the rear-right seat."
         }
       }
+    },
+    "refresh_cloud_data": {
+      "name": "Refresh Cloud Data",
+      "description": "Retrieves current cloud data without triggering a vehicle refresh. Data may be outdated if the vehicle has not checked in recently. For best results, use 30 seconds after a command."
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,21 @@ Normal updates retrieve data from the Audi Connect cloud service, and don't inte
 
 - **`vin`**: The Vehicle Identification Number (VIN) of the Audi you want to control.
 
+### Audi Connect: Refresh Cloud Data
+
+`audiconnect.refresh_cloud_data`
+
+_This_ service triggers an update request from the cloud.
+
+- Functionality: Updates data for all vehicles from the online source, mirroring the action performed at integration startup or during scheduled refresh intervals.
+- Behavior: Does not force a vehicle-side data refresh. Consequently, if vehicles haven't recently pushed updates, retrieved data might be outdated.
+- Recommended Usage: Ideal for post-command updates (e.g., after initiating climate control). To ensure data accuracy, a delay of approximately 30 seconds is recommended between command issuance and this service call.
+- Note: This service essentially replicates the function of restarting the integration, offering a more granular control over data refresh moments.
+
+#### Service Parameters
+
+- `none`
+
 ### Audi Connect: Execute Vehicle Action
 
 `audiconnect.execute_vehicle_action`


### PR DESCRIPTION
## New Service Call - Refresh Cloud Data
### `audiconnect.refresh_cloud_data`

Introduces the `audiconnect.refresh_cloud_data` service call. The service leverages an existing backend function, now made accessible through the Home Assistant UI. It's designed to update vehicle data from the cloud for all vehicles linked to an account **without** initiating a vehicle-side refresh.

### Use Case:
Given some limitations with the "Refresh Vehicle Data" functionality, this service call provides a workaround by allowing users to manually trigger data updates. It's particularly useful for users who prefer to extend the default refresh interval significantly and wish to manually request updates at specific moments, such as after starting climate control or during periods of inactivity.

### Service Call Description:

- Functionality: Updates data for all vehicles from the cloud, mirroring the action performed at integration startup or during scheduled refresh intervals.
- Behavior: Does not force a vehicle-side data refresh. Consequently, if vehicles haven't recently pushed updates, retrieved data might be outdated.
- Recommended Usage: Ideal for post-command updates (e.g., after initiating climate control). To ensure data accuracy, a delay of approximately 30 seconds is recommended between command issuance and this service call.
- Note: This service essentially replicates the function of restarting the integration or polling for updates, offering a more granular control over data refresh moments.

This addition aims to enhance user control over data updates, addressing specific scenarios where updated information is crucial without unnecessarily frequent automated refreshes.