### PR TITLE
fix: Documentation Cleanup

### DIFF
--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -124,7 +124,7 @@
     },
     "refresh_cloud_data": {
       "name": "Refresh Cloud Data",
-      "description": "Retrieves current cloud data without triggering a vehicle refresh. Data may be outdated if the vehicle has not checked in recently. For best results, use 30 seconds after a command."
+      "description": "Retrieves current cloud data without triggering a vehicle refresh. Data may be outdated if the vehicle has not checked in recently."
     }
   }
 }

--- a/custom_components/audiconnect/translations/de.json
+++ b/custom_components/audiconnect/translations/de.json
@@ -124,7 +124,7 @@
     },
     "refresh_cloud_data": {
       "name": "Cloud-Daten aktualisieren",
-      "description": "Ruft aktuelle Cloud-Daten ab, ohne eine Fahrzeugaktualisierung auszulösen. Die Daten sind möglicherweise veraltet, wenn das Fahrzeug nicht kürzlich eingecheckt wurde. Die besten Ergebnisse erzielen Sie, wenn Sie 30 Sekunden nach einem Befehl verwenden."
+      "description": "Ruft aktuelle Cloud-Daten ab, ohne eine Fahrzeugaktualisierung auszulösen. Die Daten sind möglicherweise veraltet, wenn das Fahrzeug nicht kürzlich eingecheckt wurde."
     }
   }
 }

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -124,7 +124,7 @@
     },
     "refresh_cloud_data": {
       "name": "Refresh Cloud Data",
-      "description": "Retrieves current cloud data without triggering a vehicle refresh. Data may be outdated if the vehicle has not checked in recently. For best results, use 30 seconds after a command."
+      "description": "Retrieves current cloud data without triggering a vehicle refresh. Data may be outdated if the vehicle has not checked in recently."
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,6 @@ _This_ service triggers an update request from the cloud.
 
 - Functionality: Updates data for all vehicles from the online source, mirroring the action performed at integration startup or during scheduled refresh intervals.
 - Behavior: Does not force a vehicle-side data refresh. Consequently, if vehicles haven't recently pushed updates, retrieved data might be outdated.
-- Recommended Usage: Ideal for post-command updates (e.g., after initiating climate control). To ensure data accuracy, a delay of approximately 30 seconds is recommended between command issuance and this service call.
 - Note: This service essentially replicates the function of restarting the integration, offering a more granular control over data refresh moments.
 
 #### Service Parameters

--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,7 @@ _This_ service triggers an update request from the cloud.
 
 - Functionality: Updates data for all vehicles from the online source, mirroring the action performed at integration startup or during scheduled refresh intervals.
 - Behavior: Does not force a vehicle-side data refresh. Consequently, if vehicles haven't recently pushed updates, retrieved data might be outdated.
-- Note: This service essentially replicates the function of restarting the integration, offering a more granular control over data refresh moments.
+- Note: This service replicates the function of active polling without scheduling, offering a more granular control over data refresh moments.
 
 #### Service Parameters
 


### PR DESCRIPTION
Since the `update` (refresh_cloud_data) service is called after vehicle actions automatically, we shouldn't mention the user needs to do this manually.