### PR TITLE
fix: API Timeout Increase

### DIFF
--- a/custom_components/audiconnect/audi_api.py
+++ b/custom_components/audiconnect/audi_api.py
@@ -10,7 +10,7 @@ from aiohttp.hdrs import METH_GET, METH_POST, METH_PUT
 
 from typing import Dict
 
-TIMEOUT = 10
+TIMEOUT = 30
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Audi API Latency can cause the current 10 second timeout to repeatedly fail, while a longer timeout succeeds. Extended latency has been seen in Audi App and HA recently.