### PR TITLE
fix: Native unit of measurement

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -16,10 +16,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 
-from homeassistant.util.unit_system import (
-    US_CUSTOMARY_SYSTEM,
-)
-
 from .audi_account import AudiAccount
 
 from .const import (
@@ -118,14 +114,8 @@ async def async_setup_entry(hass, config_entry):
 
     account = config_entry.data.get(CONF_USERNAME)
 
-    unit_system = "metric"
-    if hass.config.units is US_CUSTOMARY_SYSTEM:
-        unit_system = "imperial"
-
     if account not in hass.data[DOMAIN]:
-        data = hass.data[DOMAIN][account] = AudiAccount(
-            hass, config_entry, unit_system=unit_system
-        )
+        data = hass.data[DOMAIN][account] = AudiAccount(hass, config_entry)
         data.init_connection()
     else:
         data = hass.data[DOMAIN][account]

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -71,13 +71,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class AudiAccount(AudiConnectObserver):
-    def __init__(self, hass, config_entry, unit_system: str):
+    def __init__(self, hass, config_entry):
         """Initialize the component state."""
         self.hass = hass
         self.config_entry = config_entry
         self.config_vehicles = set()
         self.vehicles = set()
-        self.unit_system = unit_system
 
     def init_connection(self):
         session = async_get_clientsession(self.hass)
@@ -131,9 +130,7 @@ class AudiAccount(AudiConnectObserver):
                 cfg_vehicle.vehicle = vehicle
                 self.config_vehicles.add(cfg_vehicle)
 
-                dashboard = Dashboard(
-                    self.connection, vehicle, unit_system=self.unit_system
-                )
+                dashboard = Dashboard(self.connection, vehicle)
 
                 for instrument in (
                     instrument

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -378,8 +378,7 @@ class LastUpdate(Instrument):
 
     @property
     def state(self):
-        val = super().state
-        return val.astimezone(tz=None).isoformat() if val else None
+        return super().state
 
 
 def create_instruments():

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -34,9 +34,6 @@ class Instrument:
     def __repr__(self):
         return self.full_name
 
-    def configurate(self, **args):
-        pass
-
     def camel2slug(self, s):
         """Convert camelCase to camel_case.
             >>> camel2slug('fooBar')
@@ -63,8 +60,6 @@ class Instrument:
             return False
 
         # _LOGGER.debug("%s is supported", self)
-
-        self.configurate(**config)
 
         return True
 
@@ -150,14 +145,6 @@ class Sensor(Instrument):
         self.state_class = state_class
         self._convert = False
 
-    def configurate(self, unit_system=None, **config):
-        if self._unit and unit_system == "imperial" and "km" in self._unit:
-            self._unit = "mi"
-            self._convert = True
-        elif self._unit and unit_system == "metric" and "mi" in self._unit:
-            self._unit = "km"
-            self._convert = True
-
     @property
     def is_mutable(self):
         return False
@@ -171,13 +158,7 @@ class Sensor(Instrument):
 
     @property
     def state(self):
-        val = super().state
-        if val and self._unit and "mi" in self._unit and self._convert is True:
-            return round(val / 1.609344)
-        elif val and self._unit and "km" in self._unit and self._convert is True:
-            return round(val * 1.609344)
-        else:
-            return val
+        return super().state
 
     @property
     def unit(self):

--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -32,13 +32,13 @@ class AudiSensor(AudiEntity, SensorEntity):
     """Representation of a Audi sensor."""
 
     @property
-    def state(self):
-        """Return the state."""
+    def native_value(self):
+        """Return the native value."""
         return self._instrument.state
 
     @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
+    def native_unit_of_measurement(self):
+        """Return the native unit of measurement."""
         return self._instrument.unit
 
     @property


### PR DESCRIPTION
### Issue
- As pointed out by issue #342 the unit of measurement can't be adjusted from the front end. 
- This update allows the use of "Unit of measurement" from the front end to convert values on the fly.

### Fix
- Updating sensors to use `native_unit_of_measurement` and `native_value`.
- `unit_system` is no longer needed. Removing all instances throughout the integration.
- Last_Update state should not be a string