### PR TITLE
fix: async_add_job will be deprecated in HA 2025.4

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -149,27 +149,27 @@ class AudiAccount(AudiConnectObserver):
                     if instrument._component == "lock":
                         cfg_vehicle.locks.add(instrument)
 
-            self.hass.async_add_job(
+            self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setup(
                     self.config_entry, "sensor"
                 )
             )
-            self.hass.async_add_job(
+            self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setup(
                     self.config_entry, "binary_sensor"
                 )
             )
-            self.hass.async_add_job(
+            self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setup(
                     self.config_entry, "switch"
                 )
             )
-            self.hass.async_add_job(
+            self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setup(
                     self.config_entry, "device_tracker"
                 )
             )
-            self.hass.async_add_job(
+            self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setup(
                     self.config_entry, "lock"
                 )


### PR DESCRIPTION
fix for async_add_job being deprecated in HA 2025.4

> async_run_job and async_add_job are deprecated and will be removed in Home Assistant 2025.4. This deprecation does not apply to the sync API add_job method, which is not planned to be removed.
> 
> Instead, it's more efficient to use one of the other job methods, as the method of calling the job does not ever have to be worked out:
> 
> If the callable is a coroutine function running from a config entry: entry.async_create_background_task, entry.async_create_task
> 
> If the callable is a coroutine function running from another place: hass.async_create_background_task, hass.async_create_task
> 
> If the callable should run in the executor: hass.async_add_executor_job