### PR TITLE
fix: Treat SunRoof as Window

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1074,7 +1074,13 @@ class AudiConnectVehicle:
         checkRightFront = self._vehicle.fields.get("STATE_RIGHT_FRONT_WINDOW")
         checkRightRear = self._vehicle.fields.get("STATE_RIGHT_REAR_WINDOW")
         checkSunRoof = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
-        if checkLeftFront and checkLeftRear and checkRightFront and checkRightRear and checkSunRoof:
+        if (
+            checkLeftFront
+            and checkLeftRear
+            and checkRightFront
+            and checkRightRear
+            and checkSunRoof
+        ):
             return True
 
     @property

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -942,17 +942,6 @@ class AudiConnectVehicle:
             return True
 
     @property
-    def sun_roof(self):
-        if self.sun_roof_supported:
-            return self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
-
-    @property
-    def sun_roof_supported(self):
-        check = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
-        if check is not None:
-            return True
-
-    @property
     def preheater_active(self):
         if self.preheater_active_supported:
             res = (
@@ -1084,7 +1073,8 @@ class AudiConnectVehicle:
         checkLeftRear = self._vehicle.fields.get("STATE_LEFT_REAR_WINDOW")
         checkRightFront = self._vehicle.fields.get("STATE_RIGHT_FRONT_WINDOW")
         checkRightRear = self._vehicle.fields.get("STATE_RIGHT_REAR_WINDOW")
-        if checkLeftFront and checkLeftRear and checkRightFront and checkRightRear:
+        checkSunRoof = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
+        if checkLeftFront and checkLeftRear and checkRightFront and checkRightRear and checkSunRoof:
             return True
 
     @property
@@ -1094,11 +1084,13 @@ class AudiConnectVehicle:
             checkLeftRear = self._vehicle.fields.get("STATE_LEFT_REAR_WINDOW")
             checkRightFront = self._vehicle.fields.get("STATE_RIGHT_FRONT_WINDOW")
             checkRightRear = self._vehicle.fields.get("STATE_RIGHT_REAR_WINDOW")
+            checkSunRoof = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
             return not (
                 checkLeftFront == "3"
                 and checkLeftRear == "3"
                 and checkRightFront == "3"
                 and checkRightRear == "3"
+                and checkSunRoof == "3"
             )
 
     @property
@@ -1136,6 +1128,15 @@ class AudiConnectVehicle:
     def right_rear_window_open(self):
         if self.right_rear_window_open_supported:
             return self._vehicle.fields.get("STATE_RIGHT_REAR_WINDOW") != "3"
+
+    @property
+    def sun_roof_supported(self):
+        return self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
+
+    @property
+    def sun_roof(self):
+        if self.sun_roof_supported:
+            return self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER") != "3"
 
     @property
     def any_door_unlocked_supported(self):


### PR DESCRIPTION
### Summary
The `sunRoof` should be treated as a window.
#358 fixed the sunroof becoming unavailable, but during testing showed it was always returning `Open`. This fixes that and groups it with the other windows, following the same logic.

### Technical
- Moving `sun_roof` and `sun_roof_supported` to be grouped with the windows in `audi_connect_account.py`
- Using same logic as other windows (It is defined with the other windows in `audi_models.py > appendWindowState`)
- Updated `any_window_open` to also check the sunroof

_Tested and working as expected_