### PR TITLE
fix: update_vehicle_statusreport

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 
 from .audi_services import AudiService
 from .audi_api import AudiAPI
-from .util import log_exception, get_attr, parse_int, parse_float
+from .util import log_exception, get_attr, parse_int, parse_float, to_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -480,24 +480,6 @@ class AudiConnectVehicle:
         if not self.support_status_report:
             return
 
-        def to_datetime(time_value):
-            """Converts timestamp to datetime object if it's a string, or returns it directly if already datetime."""
-            if isinstance(time_value, datetime):
-                return time_value  # Return the datetime object directly if already datetime
-            elif isinstance(time_value, str):
-                formats = [
-                    "%Y-%m-%d %H:%M:%S%z",  # Format: 2024-04-12 05:56:17+00:00
-                    "%Y-%m-%dT%H:%M:%S.%fZ",  # Format: 2024-04-12T05:56:13.025Z
-                ]
-                for fmt in formats:
-                    try:
-                        return datetime.strptime(time_value, fmt).replace(
-                            tzinfo=timezone.utc
-                        )
-                    except ValueError:
-                        continue
-            return None  # Return None if input is neither a valid string nor a datetime object
-
         try:
             status = await self._audi_service.get_stored_vehicle_data(self._vehicle.vin)
             self._vehicle.fields = {
@@ -506,10 +488,8 @@ class AudiConnectVehicle:
             }
 
             # Initialize with a default very old datetime
-            self._vehicle.state["last_update_time"] = datetime(
-                1970, 1, 1, tzinfo=timezone.utc
-            )
-
+            self._vehicle.state["last_update_time"] = datetime(1970, 1, 1, tzinfo=timezone.utc)
+            
             # Update with the newest carCapturedTimestamp from data_fields
             for f in status.data_fields:
                 new_time = to_datetime(f.measure_time)
@@ -517,7 +497,7 @@ class AudiConnectVehicle:
                     self._vehicle.state["last_update_time"] = max(
                         self._vehicle.state["last_update_time"], new_time
                     )
-
+            
             # Update with the newest carCapturedTimestamp from states
             for state in status.states:
                 new_time = to_datetime(state.get("measure_time"))
@@ -529,7 +509,7 @@ class AudiConnectVehicle:
             # Update other states
             for state in status.states:
                 self._vehicle.state[state["name"]] = state["value"]
-
+                
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
@@ -538,16 +518,12 @@ class AudiConnectVehicle:
             else:
                 self.log_exception_once(
                     resp_exception,
-                    "Unable to obtain the vehicle status report of {}".format(
-                        self._vehicle.vin
-                    ),
+                    "Unable to obtain the vehicle status report of {}".format(self._vehicle.vin)
                 )
         except Exception as exception:
             self.log_exception_once(
                 exception,
-                "Unable to obtain the vehicle status report of {}".format(
-                    self._vehicle.vin
-                ),
+                "Unable to obtain the vehicle status report of {}".format(self._vehicle.vin)
             )
 
     async def update_vehicle_position(self):

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 
 from .audi_services import AudiService
 from .audi_api import AudiAPI
-from .util import log_exception, get_attr, parse_int, parse_float, to_datetime
+from .util import log_exception, get_attr, parse_int, parse_float, parse_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -494,7 +494,7 @@ class AudiConnectVehicle:
 
             # Update with the newest carCapturedTimestamp from data_fields
             for f in status.data_fields:
-                new_time = to_datetime(f.measure_time)
+                new_time = parse_datetime(f.measure_time)
                 if new_time:
                     self._vehicle.state["last_update_time"] = max(
                         self._vehicle.state["last_update_time"], new_time
@@ -502,7 +502,7 @@ class AudiConnectVehicle:
 
             # Update with the newest carCapturedTimestamp from states
             for state in status.states:
-                new_time = to_datetime(state.get("measure_time"))
+                new_time = parse_datetime(state.get("measure_time"))
                 if new_time:
                     self._vehicle.state["last_update_time"] = max(
                         self._vehicle.state["last_update_time"], new_time

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -481,21 +481,22 @@ class AudiConnectVehicle:
             return
 
         def to_datetime(time_value):
-            """ Converts timestamp to datetime object if it's a string, or returns it directly if already datetime. """
+            """Converts timestamp to datetime object if it's a string, or returns it directly if already datetime."""
             if isinstance(time_value, datetime):
                 return time_value  # Return the datetime object directly if already datetime
             elif isinstance(time_value, str):
                 formats = [
                     "%Y-%m-%d %H:%M:%S%z",  # Format: 2024-04-12 05:56:17+00:00
-                    "%Y-%m-%dT%H:%M:%S.%fZ"  # Format: 2024-04-12T05:56:13.025Z
+                    "%Y-%m-%dT%H:%M:%S.%fZ",  # Format: 2024-04-12T05:56:13.025Z
                 ]
                 for fmt in formats:
                     try:
-                        return datetime.strptime(time_value, fmt).replace(tzinfo=timezone.utc)
+                        return datetime.strptime(time_value, fmt).replace(
+                            tzinfo=timezone.utc
+                        )
                     except ValueError:
                         continue
             return None  # Return None if input is neither a valid string nor a datetime object
-
 
         try:
             status = await self._audi_service.get_stored_vehicle_data(self._vehicle.vin)
@@ -505,8 +506,10 @@ class AudiConnectVehicle:
             }
 
             # Initialize with a default very old datetime
-            self._vehicle.state["last_update_time"] = datetime(1970, 1, 1, tzinfo=timezone.utc)
-            
+            self._vehicle.state["last_update_time"] = datetime(
+                1970, 1, 1, tzinfo=timezone.utc
+            )
+
             # Update with the newest carCapturedTimestamp from data_fields
             for f in status.data_fields:
                 new_time = to_datetime(f.measure_time)
@@ -514,7 +517,7 @@ class AudiConnectVehicle:
                     self._vehicle.state["last_update_time"] = max(
                         self._vehicle.state["last_update_time"], new_time
                     )
-            
+
             # Update with the newest carCapturedTimestamp from states
             for state in status.states:
                 new_time = to_datetime(state.get("measure_time"))
@@ -526,7 +529,7 @@ class AudiConnectVehicle:
             # Update other states
             for state in status.states:
                 self._vehicle.state[state["name"]] = state["value"]
-                
+
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
@@ -535,12 +538,16 @@ class AudiConnectVehicle:
             else:
                 self.log_exception_once(
                     resp_exception,
-                    "Unable to obtain the vehicle status report of {}".format(self._vehicle.vin)
+                    "Unable to obtain the vehicle status report of {}".format(
+                        self._vehicle.vin
+                    ),
                 )
         except Exception as exception:
             self.log_exception_once(
                 exception,
-                "Unable to obtain the vehicle status report of {}".format(self._vehicle.vin)
+                "Unable to obtain the vehicle status report of {}".format(
+                    self._vehicle.vin
+                ),
             )
 
     async def update_vehicle_position(self):

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -488,8 +488,10 @@ class AudiConnectVehicle:
             }
 
             # Initialize with a default very old datetime
-            self._vehicle.state["last_update_time"] = datetime(1970, 1, 1, tzinfo=timezone.utc)
-            
+            self._vehicle.state["last_update_time"] = datetime(
+                1970, 1, 1, tzinfo=timezone.utc
+            )
+
             # Update with the newest carCapturedTimestamp from data_fields
             for f in status.data_fields:
                 new_time = to_datetime(f.measure_time)
@@ -497,7 +499,7 @@ class AudiConnectVehicle:
                     self._vehicle.state["last_update_time"] = max(
                         self._vehicle.state["last_update_time"], new_time
                     )
-            
+
             # Update with the newest carCapturedTimestamp from states
             for state in status.states:
                 new_time = to_datetime(state.get("measure_time"))
@@ -509,7 +511,7 @@ class AudiConnectVehicle:
             # Update other states
             for state in status.states:
                 self._vehicle.state[state["name"]] = state["value"]
-                
+
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
@@ -518,12 +520,16 @@ class AudiConnectVehicle:
             else:
                 self.log_exception_once(
                     resp_exception,
-                    "Unable to obtain the vehicle status report of {}".format(self._vehicle.vin)
+                    "Unable to obtain the vehicle status report of {}".format(
+                        self._vehicle.vin
+                    ),
                 )
         except Exception as exception:
             self.log_exception_once(
                 exception,
-                "Unable to obtain the vehicle status report of {}".format(self._vehicle.vin)
+                "Unable to obtain the vehicle status report of {}".format(
+                    self._vehicle.vin
+                ),
             )
 
     async def update_vehicle_position(self):

--- a/custom_components/audiconnect/util.py
+++ b/custom_components/audiconnect/util.py
@@ -1,5 +1,5 @@
 from functools import reduce
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/audiconnect/util.py
+++ b/custom_components/audiconnect/util.py
@@ -1,4 +1,5 @@
 from functools import reduce
+from datetime import datetime
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,3 +38,19 @@ def parse_float(val: str):
         return float(val)
     except (ValueError, TypeError):
         return None
+
+def to_datetime(time_value):
+    """ Converts timestamp to datetime object if it's a string, or returns it directly if already datetime. """
+    if isinstance(time_value, datetime):
+        return time_value  # Return the datetime object directly if already datetime
+    elif isinstance(time_value, str):
+        formats = [
+            "%Y-%m-%d %H:%M:%S%z",  # Format: 2024-04-12 05:56:17+00:00
+            "%Y-%m-%dT%H:%M:%S.%fZ"  # Format: 2024-04-12T05:56:13.025Z
+        ]
+        for fmt in formats:
+            try:
+                return datetime.strptime(time_value, fmt).replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+    return None

--- a/custom_components/audiconnect/util.py
+++ b/custom_components/audiconnect/util.py
@@ -39,14 +39,15 @@ def parse_float(val: str):
     except (ValueError, TypeError):
         return None
 
+
 def to_datetime(time_value):
-    """ Converts timestamp to datetime object if it's a string, or returns it directly if already datetime. """
+    """Converts timestamp to datetime object if it's a string, or returns it directly if already datetime."""
     if isinstance(time_value, datetime):
         return time_value  # Return the datetime object directly if already datetime
     elif isinstance(time_value, str):
         formats = [
             "%Y-%m-%d %H:%M:%S%z",  # Format: 2024-04-12 05:56:17+00:00
-            "%Y-%m-%dT%H:%M:%S.%fZ"  # Format: 2024-04-12T05:56:13.025Z
+            "%Y-%m-%dT%H:%M:%S.%fZ",  # Format: 2024-04-12T05:56:13.025Z
         ]
         for fmt in formats:
             try:

--- a/custom_components/audiconnect/util.py
+++ b/custom_components/audiconnect/util.py
@@ -40,7 +40,7 @@ def parse_float(val: str):
         return None
 
 
-def to_datetime(time_value):
+def parse_datetime(time_value):
     """Converts timestamp to datetime object if it's a string, or returns it directly if already datetime."""
     if isinstance(time_value, datetime):
         return time_value  # Return the datetime object directly if already datetime


### PR DESCRIPTION
Certain vehicles are reporting different timestamp formats for different sensors. The impacts might be the vehicle status report not updating. This could be the reason the Q4 and e-tron aren't working.
This PR attempts to parse the timestamps. 

error in log:
```2024-04-12 06:05:50.056 ERROR (MainThread) [custom_components.audiconnect.audi_connect_account] Unable to obtain the vehicle status report of WA1BCBFZ7PP070298: '>' not supported between instances of 'str' and 'datetime.datetime'
Traceback (most recent call last):
  File "/config/custom_components/audiconnect/audi_connect_account.py", line 495, in update_vehicle_statusreport
    self._vehicle.state["last_update_time"] = max(
                                              ^^^^
TypeError: '>' not supported between instances of 'str' and 'datetime.datetime'
```

One user's log of `LIGHT_STATUS` timestamp from #207 :
```
2024-04-12 06:05:50.053 DEBUG (MainThread) [custom_components.audiconnect.audi_models] Timestamp retrieved for 'LIGHT_STATUS': 2024-04-12T05:56:13.025Z
```

My log for the same sensor:
```
2024-04-12 09:54:30.871 DEBUG (MainThread) [custom_components.audiconnect.audi_models] Timestamp retrieved for 'LIGHT_STATUS': 2024-04-12 02:30:40+00:00
```