### PR TITLE
fix: Handle Device_Tracker missing timestamp gracefully

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -556,7 +556,7 @@ class AudiConnectVehicle:
                     # Log a warning and use None or a placeholder for timestamp and parktime
                     timestamp = None
                     parktime = None
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Timestamp not available for vehicle position data of VIN: %s.",
                         redacted_vin,
                     )

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -572,8 +572,8 @@ class AudiConnectVehicle:
                 self._vehicle.state["position"] = {
                     "latitude": resp["data"]["lat"],
                     "longitude": resp["data"]["lon"],
-                    "timestamp": resp["data"]["carCapturedTimestamp"],
-                    "parktime": resp["data"]["carCapturedTimestamp"],
+                    "timestamp": timestamp,
+                    "parktime": parktime,
                 }
 
                 _LOGGER.debug(

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -553,7 +553,7 @@ class AudiConnectVehicle:
                     timestamp = resp["data"]["carCapturedTimestamp"]
                     parktime = resp["data"]["carCapturedTimestamp"]
                 else:
-                    # Log a warning and use None or a placeholder for timestamp and parktime
+                    # Log and use None timestamp and parktime
                     timestamp = None
                     parktime = None
                     _LOGGER.debug(

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -547,8 +547,19 @@ class AudiConnectVehicle:
             if resp is not None:
                 redacted_lat = re.sub(r"\d", "#", str(resp["data"]["lat"]))
                 redacted_lon = re.sub(r"\d", "#", str(resp["data"]["lon"]))
-                timestamp = resp["data"]["carCapturedTimestamp"]
-                parktime = resp["data"]["carCapturedTimestamp"]
+                
+                # Check if 'carCapturedTimestamp' is available in the data
+                if "carCapturedTimestamp" in resp["data"]:
+                    timestamp = resp["data"]["carCapturedTimestamp"]
+                    parktime = resp["data"]["carCapturedTimestamp"]
+                else:
+                    # Log a warning and use None or a placeholder for timestamp and parktime
+                    timestamp = None
+                    parktime = None
+                    _LOGGER.warning(
+                        "Timestamp not available for vehicle position data of VIN: %s.",
+                        redacted_vin,
+                    )
                 _LOGGER.debug(
                     "Vehicle position data received for VIN: %s, lat: %s, lon: %s, timestamp: %s, parktime: %s",
                     redacted_vin,

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -547,7 +547,7 @@ class AudiConnectVehicle:
             if resp is not None:
                 redacted_lat = re.sub(r"\d", "#", str(resp["data"]["lat"]))
                 redacted_lon = re.sub(r"\d", "#", str(resp["data"]["lon"]))
-                
+
                 # Check if 'carCapturedTimestamp' is available in the data
                 if "carCapturedTimestamp" in resp["data"]:
                     timestamp = resp["data"]["carCapturedTimestamp"]


### PR DESCRIPTION
Intermittent issues with `device_tracker` are reported in #307 . Updated Error logs are pointing to no timestamp being reported. Adding to gracefully handle this scenario. 

I'd prefer to default to the last_update_time timestamp, but maybe in the future on a beta branch. 
Currently using `None` as default and its working for me. Looking at `dashboard.py`, `None` is also used by default for these values there.

https://github.com/audiconnect/audi_connect_ha/blob/master/custom_components/audiconnect/dashboard.py#L298-L326

I've tested hardcoding `None` into both values as below and the tracker is working as expected. It seems so long as lat/lon are provided it will work.
```python
                self._vehicle.state["position"] = {
                    "latitude": resp["data"]["lat"],
                    "longitude": resp["data"]["lon"],
                    "timestamp": None,
                    "parktime": None,
                }
```
