### PR TITLE
fix: "Secondary Engine Range" Unavailable when 0

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1445,7 +1445,7 @@ class AudiConnectVehicle:
     @property
     def secondary_engine_range_supported(self):
         check = self._vehicle.state.get("secondaryEngineRange")
-        if check and check != "unsupported":
+        if check is not None and check != "unsupported":
             return True
 
     @property


### PR DESCRIPTION
"Secondary Engine Range" is reporting the sensor as Unavailable when value is 0. The sensor should still show as available, but display 0.
```
2024-04-11 06:00:02.276 DEBUG (MainThread) [custom_components.audiconnect.audi_models] Found and appended state with timestamp: name=secondaryEngineRange, tsoff=-2, loc=['fuelStatus', 'rangeStatus', 'value', 'carCapturedTimestamp'], val=0, ts=2024-04-11 04:17:04+00:00
```
![321622546-df97d7bb-0c2b-4616-9c6f-9529d7ce741e](https://github.com/audiconnect/audi_connect_ha/assets/104224685/d66d11f6-933e-4154-925f-3961677e52cb)

The issue is due to python considering "0" as Falsy. We need to specifically check if it is neither `None` or `unsupported`.

_tested and working with this PR_
