### PR TITLE
fix: External Power `Unavailable`

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1568,13 +1568,17 @@ class AudiConnectVehicle:
     def external_power(self):
         """Return external Power"""
         if self.external_power_supported:
-            return self._vehicle.state.get("externalPower")
+            external_power_status = self._vehicle.state.get("externalPower")
+            if external_power_status == "unavailable":
+                return "Not Ready"
+            elif external_power_status == "ready":
+                return "Ready"
+            else:
+                return external_power_status
 
     @property
     def external_power_supported(self):
-        check = self._vehicle.state.get("externalPower")
-        if check:
-            return True
+        return self._vehicle.state.get("externalPower") is not None
 
     @property
     def plug_led_color(self):


### PR DESCRIPTION
"External Power" sensor returns the val of "Unavailable". This leads HA to believe the sensor is unavailable and does not report the sensor as active.
```
2024-04-11 06:00:02.277 DEBUG (MainThread) [custom_components.audiconnect.audi_models] Found and appended state with timestamp: name=externalPower, tsoff=-1, loc=['charging', 'plugStatus', 'value', 'carCapturedTimestamp'], val=unavailable, ts=2024-04-10 22:48:14+00:00
```
This PR corrects this by translating `unavailable` to `Not Ready`.

#### Future Changes
A lot of these sensors should be changed to binary sensors, but if we go ahead and change them now, the old sensor will remain as a duplicate. We need to figure out migration and/or I think the different entities should have unique ID's so HA can recognize them as the same.