### PR TITLE
fix: Trip Data

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -832,6 +832,7 @@ class AudiConnectVehicle:
                 "traveltime": td_cur.traveltime,
                 "timestamp": td_cur.timestamp,
                 "overallMileage": td_cur.overallMileage,
+                "zeroEmissionDistance": td_cur.zeroEmissionDistance,
             }
             self._vehicle.state[kind.lower() + "_reset"] = {
                 "tripID": td_rst.tripID,
@@ -843,6 +844,7 @@ class AudiConnectVehicle:
                 "traveltime": td_rst.traveltime,
                 "timestamp": td_rst.timestamp,
                 "overallMileage": td_rst.overallMileage,
+                "zeroEmissionDistance": td_rst.zeroEmissionDistance,
             }
 
         except TimeoutError:

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -449,10 +449,10 @@ class AudiConnectVehicle:
             self._no_error = True
             info = "statusreport"
             await self.call_update(self.update_vehicle_statusreport, 3)
-            # info = "shortterm"
-            # await self.call_update(self.update_vehicle_shortterm, 3)
-            # info = "longterm"
-            # await self.call_update(self.update_vehicle_longterm, 3)
+            info = "shortterm"
+            await self.call_update(self.update_vehicle_shortterm, 3)
+            info = "longterm"
+            await self.call_update(self.update_vehicle_longterm, 3)
             info = "position"
             await self.call_update(self.update_vehicle_position, 3)
             info = "climater"

--- a/custom_components/audiconnect/audi_models.py
+++ b/custom_components/audiconnect/audi_models.py
@@ -444,6 +444,10 @@ class TripDataResponse:
         if "overallMileage" in data:
             self.overallMileage = int(data["overallMileage"])
 
+        self.zeroEmissionDistance = None
+        if "zeroEmissionDistance" in data:
+            self.zeroEmissionDistance = int(data["zeroEmissionDistance"])
+
 
 class Field:
     IDS = {

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -337,7 +337,7 @@ class AudiService:
             key=lambda k: k["overallMileage"],
             reverse=True,
         )
-        #_LOGGER.debug("get_tripdata: td_sorted: %s", td_sorted)
+        # _LOGGER.debug("get_tripdata: td_sorted: %s", td_sorted)
         td_current = td_sorted[0]
         _LOGGER.debug("TRIP DATA: td_current: %s", td_current)
         # FIX, TR/2023-03-25: Assign just in case td_sorted contains only one item

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -337,10 +337,12 @@ class AudiService:
             key=lambda k: k["overallMileage"],
             reverse=True,
         )
-
+        #_LOGGER.debug("get_tripdata: td_sorted: %s", td_sorted)
         td_current = td_sorted[0]
+        _LOGGER.debug("TRIP DATA: td_current: %s", td_current)
         # FIX, TR/2023-03-25: Assign just in case td_sorted contains only one item
-        td_reset_trip = td_sorted[0]
+        td_reset_trip = td_sorted[1]
+        _LOGGER.debug("TRIP DATA: td_reset_trip: %s", td_reset_trip)
 
         for trip in td_sorted:
             if (td_current["startMileage"] - trip["startMileage"]) > 2:

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -341,7 +341,7 @@ class AudiService:
         td_current = td_sorted[0]
         _LOGGER.debug("TRIP DATA: td_current: %s", td_current)
         # FIX, TR/2023-03-25: Assign just in case td_sorted contains only one item
-        td_reset_trip = td_sorted[1]
+        td_reset_trip = td_sorted[0]
         _LOGGER.debug("TRIP DATA: td_reset_trip: %s", td_reset_trip)
 
         for trip in td_sorted:

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -145,7 +145,7 @@ class Sensor(Instrument):
         state_class=None,
         device_class=None,
         entity_category=None,
-        extra_state_attributes=None
+        extra_state_attributes=None,
     ):
         super().__init__(component="sensor", attr=attr, name=name, icon=icon)
         self.device_class = device_class
@@ -376,9 +376,10 @@ class TripData(Instrument):
             "startMileage": td["startMileage"],
             "traveltime": td["traveltime"],
             "timestamp": parse_datetime(td["timestamp"]),
-            "overallMileage": td["overallMileage"]
+            "overallMileage": td["overallMileage"],
         }
         return attr
+
 
 class LastUpdate(Instrument):
     def __init__(self):

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -370,7 +370,9 @@ class TripData(Instrument):
     def extra_state_attributes(self):
         td = super().state
         attr = {
-            "averageElectricEngineConsumption": td.get("averageElectricEngineConsumption", None),
+            "averageElectricEngineConsumption": td.get(
+                "averageElectricEngineConsumption", None
+            ),
             "averageFuelConsumption": td.get("averageFuelConsumption", None),
             "averageSpeed": td.get("averageSpeed", None),
             "mileage": td.get("mileage", None),

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -370,13 +370,15 @@ class TripData(Instrument):
     def extra_state_attributes(self):
         td = super().state
         attr = {
-            "averageFuelConsumption": td["averageFuelConsumption"],
-            "averageSpeed": td["averageSpeed"],
-            "mileage": td["mileage"],
-            "startMileage": td["startMileage"],
-            "traveltime": td["traveltime"],
-            "timestamp": parse_datetime(td["timestamp"]),
-            "overallMileage": td["overallMileage"],
+            "averageElectricEngineConsumption": td.get("averageElectricEngineConsumption", None),
+            "averageFuelConsumption": td.get("averageFuelConsumption", None),
+            "averageSpeed": td.get("averageSpeed", None),
+            "mileage": td.get("mileage", None),
+            "overallMileage": td.get("overallMileage", None),
+            "startMileage": td.get("startMileage", None),
+            "traveltime": td.get("traveltime", None),
+            "tripID": td.get("tripID", None),
+            "zeroEmissionDistance": td.get("zeroEmissionDistance", None),
         }
         return attr
 

--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -55,3 +55,8 @@ class AudiSensor(AudiEntity, SensorEntity):
     def entity_category(self):
         """Return the entity_category."""
         return self._instrument.entity_category
+
+    @property
+    def extra_state_attributes(self):
+        """Return additional state attributes."""
+        return self._instrument.extra_state_attributes


### PR DESCRIPTION
### Purpose
This PR brings functionality back to the short term and long term trip data sensors.

### The Issue
The primary issue was the `state` of the sensor returning the full data for the relevant trip which exceeded 255 characters.

### The Solution
State now displays the timestamp from the trip, and attributes have been added to the sensor for the other trip data. Using `get` with defaults to avoid keyerrors.

### Testing
Tested with hardcoded values known to not be available. Tests show the code handled the keyerrors gracefully. Tested with `None` hardcoded as well and 'null' is properly reported.
