### PR TITLE
fix: Oil Level

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -945,20 +945,23 @@ class AudiConnectVehicle:
     def oil_level(self):
         """Return oil level percentage"""
         if self.oil_level_supported:
-            val = self._vehicle.fields.get("OIL_LEVEL_DIPSTICKS_PERCENTAGE")
-            if isinstance(val, bool):
-                if val:
-                    return 100
-                else:
-                    return 1
-            elif parse_float(val):
-                return parse_float(val)
+            return parse_float(self._vehicle.fields.get("OIL_LEVEL_DIPSTICKS_PERCENTAGE"))
 
     @property
     def oil_level_supported(self):
-        check = self._vehicle.fields.get("OIL_LEVEL_DIPSTICKS_PERCENTAGE")
-        if check is not None:
-            return True
+        """Check if oil level is supported."""
+        return parse_float(self._vehicle.fields.get("OIL_LEVEL_DIPSTICKS_PERCENTAGE"))
+
+    @property
+    def oil_level_binary(self):
+        """Return oil level binary."""
+        if self.oil_level_binary_supported:
+            return self._vehicle.fields.get("OIL_LEVEL_DIPSTICKS_PERCENTAGE")
+
+    @property
+    def oil_level_binary_supported(self):
+        """Check if oil level is supported."""
+        return isinstance(self._vehicle.fields.get("OIL_LEVEL_DIPSTICKS_PERCENTAGE"), bool)
 
     @property
     def preheater_active(self):

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -719,6 +719,13 @@ def create_instruments():
             device_class=BinarySensorDeviceClass.SAFETY,
             icon="mdi:car-brake-abs",
         ),
+       BinarySensor(
+            attr="oil_level_binary",
+            name="Oil Level Binary",
+            icon="mdi:oil",
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
     ]
 
 


### PR DESCRIPTION
This pull request introduces a new binary sensor for the oil_level_binary and updates the logic for the oil level percentage display. The changes ensure that the percentage is only displayed if the retrieved value is a float, and the binary sensor is only displayed if the value is a bool.

The binary sensor addition aims to provide a clearer indication of the oil level status ("OK" or "Problem").

Note: I'm unable to test these changes as my vehicle does not support oil level reporting. The functionality should be validated against a vehicle that provides this data.