### PR TITLE
fix: Critical Fix - Trip Data 403

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -867,6 +867,10 @@ class AudiConnectVehicle:
     async def update_vehicle_tripdata(self, kind: str):
         redacted_vin = "*" * (len(self._vehicle.vin) - 4) + self._vehicle.vin[-4:]
         if not self.support_trip_data:
+            _LOGGER.debug(
+                "Trip data support is disabled for VIN: %s. Exiting update process.",
+                redacted_vin,
+            )
             return
         try:
             td_cur, td_rst = await self._audi_service.get_tripdata(


### PR DESCRIPTION
going back to #254 it looks like no safeguard was in place for `get_trip_data` and this was part of the reason this was disabled. This means repeated 403 responses with every update if a vehicle isn't reporting trip data.
This PR adds a check similar to the other data functions which will check once, and upon 403 will disable support for the service and wont check again until next HA restart.