### PR TITLE
fix: More 403 Handling

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -272,7 +272,7 @@ class AudiAccount(AudiConnectObserver):
             _LOGGER.debug("Refresh vehicle data failed for VIN: %s", redacted_vin)
             self.hass.bus.fire(
                 "{}_{}".format(DOMAIN, REFRESH_VEHICLE_DATA_FAILED_EVENT),
-                {"vin": redacted_vin}
+                {"vin": redacted_vin},
             )
 
         _LOGGER.info("Refreshing cloud data in %d seconds...", UPDATE_SLEEP)

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -257,26 +257,29 @@ class AudiAccount(AudiConnectObserver):
         await self._refresh_vehicle_data(vin)
 
     async def _refresh_vehicle_data(self, vin):
+        redacted_vin = "*" * (len(vin) - 4) + vin[-4:]
         res = await self.connection.refresh_vehicle_data(vin)
 
         if res is True:
-            await self.update(utcnow())
+            _LOGGER.debug("Refresh vehicle data successful for VIN: %s", redacted_vin)
             self.hass.bus.fire(
                 "{}_{}".format(DOMAIN, REFRESH_VEHICLE_DATA_COMPLETED_EVENT),
-                {"vin": vin},
+                {"vin": redacted_vin},
             )
+        elif res == "disabled":
+            _LOGGER.debug("Refresh vehicle data is disabled for VIN: %s", redacted_vin)
         else:
-            _LOGGER.exception("Error refreshing vehicle data %s", vin)
+            _LOGGER.debug("Refresh vehicle data failed for VIN: %s", redacted_vin)
             self.hass.bus.fire(
-                "{}_{}".format(DOMAIN, REFRESH_VEHICLE_DATA_FAILED_EVENT), {"vin": vin}
+                "{}_{}".format(DOMAIN, REFRESH_VEHICLE_DATA_FAILED_EVENT),
+                {"vin": redacted_vin}
             )
 
-            _LOGGER.info("Trying cloud update in %d seconds...", UPDATE_SLEEP)
-            await asyncio.sleep(UPDATE_SLEEP)
+        _LOGGER.info("Refreshing cloud data in %d seconds...", UPDATE_SLEEP)
+        await asyncio.sleep(UPDATE_SLEEP)
 
-            try:
-                _LOGGER.info("Trying cloud update now...")
-                await self.update(utcnow())
-
-            except Exception as e:
-                _LOGGER.exception("Cloud update failed: %s", str(e))
+        try:
+            _LOGGER.info("Refreshing cloud data now...")
+            await self.update(utcnow())
+        except Exception as e:
+            _LOGGER.exception("Refresh cloud data failed: %s", str(e))

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -275,11 +275,11 @@ class AudiAccount(AudiConnectObserver):
                 {"vin": redacted_vin},
             )
 
-        _LOGGER.info("Refreshing cloud data in %d seconds...", UPDATE_SLEEP)
+        _LOGGER.debug("Refreshing cloud data in %d seconds...", UPDATE_SLEEP)
         await asyncio.sleep(UPDATE_SLEEP)
 
         try:
-            _LOGGER.info("Refreshing cloud data now...")
+            _LOGGER.debug("Refreshing cloud data now...")
             await self.update(utcnow())
         except Exception as e:
             _LOGGER.exception("Refresh cloud data failed: %s", str(e))

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -275,11 +275,11 @@ class AudiAccount(AudiConnectObserver):
                 {"vin": redacted_vin},
             )
 
-        _LOGGER.debug("Refreshing cloud data in %d seconds...", UPDATE_SLEEP)
+        _LOGGER.debug("Requesting to refresh cloud data in %d seconds...", UPDATE_SLEEP)
         await asyncio.sleep(UPDATE_SLEEP)
 
         try:
-            _LOGGER.debug("Refreshing cloud data now...")
+            _LOGGER.debug("Requesting to refresh cloud data now...")
             await self.update(utcnow())
         except Exception as e:
             _LOGGER.exception("Refresh cloud data failed: %s", str(e))


### PR DESCRIPTION
### Primary Purpose
`refresh_vehicle_data` is currently returning 403. Similar to other functions, like `get_trip_data` and `get_climater` we should check once and disable further tries until a Home Assistant restart. This not only will prevent a user from over polling a forbidden request, it will also increase responsiveness by not waiting for a response each time.

### Other Code Cleanup
- Redact VINs
- Redundancy: if we're trying `update()` (Refresh Cloud Data) regardless of the `refresh_vehicle_data` success or failure, we don't need to include it in each response action. It only needs to be called at the end.
- Exception handling for `refresh_cloud_data`