### PR TITLE
fix: charging_complete_time

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1652,7 +1652,7 @@ class AudiConnectVehicle:
         if not self.remaining_charging_time_supported:
             return None
         # If there's no last update or remaining time, we can't calculate
-        if self.last_update_time is None or self.remaining_charging_time is None:
+        if self.last_update_time is None or self.remaining_charging_time == 0:
             return None
         # Calculate the complete time whenever there is a positive remaining time
         if self.remaining_charging_time > 0:

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1640,7 +1640,7 @@ class AudiConnectVehicle:
     def remaining_charging_time(self):
         """Return remaining charging time"""
         if self.remaining_charging_time_supported:
-            return self._vehicle.state.get("remainingChargingTime")
+            return self._vehicle.state.get("remainingChargingTime", 0)
 
     @property
     def remaining_charging_time_unit(self):
@@ -1648,9 +1648,7 @@ class AudiConnectVehicle:
 
     @property
     def remaining_charging_time_supported(self):
-        check = self._vehicle.state.get("remainingChargingTime")
-        if check is not None:
-            return True
+        return self.car_type in ["hybrid", "electric"]
 
     @property
     def charging_complete_time(self):
@@ -1659,7 +1657,7 @@ class AudiConnectVehicle:
         if not self.remaining_charging_time_supported:
             return None
         # If there's no last update or remaining time, we can't calculate
-        if self.last_update_time is None or self.remaining_charging_time == 0:
+        if self.last_update_time is None or self.remaining_charging_time is None:
             return None
         # Calculate the complete time whenever there is a positive remaining time
         if self.remaining_charging_time > 0:

--- a/custom_components/audiconnect/audi_models.py
+++ b/custom_components/audiconnect/audi_models.py
@@ -268,13 +268,6 @@ class VehicleDataResponse:
         val = self._getFromJson(json, loc)
         # _LOGGER.debug("Initial value retrieved for '%s': %s", name, val)
 
-        # Special handling for remainingChargingTime
-        if name == "remainingChargingTime" and val is None:
-            val = 0
-            _LOGGER.debug(
-                "TRY APPEND STATE: 'remainingChargingTime' adjusted to 0 due to None value"
-            )
-
         if val is not None:
             loc[tsoff:] = ["carCapturedTimestamp"]
             # _LOGGER.debug("Updated loc for timestamp retrieval: %s", loc)


### PR DESCRIPTION
Like discussed in https://github.com/audiconnect/audi_connect_ha/issues/401 we always set remaining_charging_time to at least 0 in https://github.com/audiconnect/audi_connect_ha/blob/5055bc34b14e99fda066ce9975da9e8c98ee99da/custom_components/audiconnect/audi_connect_account.py#L1655