### PR TITLE
fix: Allow user to show raw position data in logs

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -606,7 +606,7 @@ class AudiConnectVehicle:
             # Note: This will log sensitive data. To stop logging this data:
             # 1. Add the '#' back at the start of the _LOGGER.debug line.
             # 2. Save the file and restart Home Assistant again.
-            #_LOGGER.debug("POSITION - UNREDACTED SENSITIVE DATA: Raw vehicle position data: %s", resp)
+            # _LOGGER.debug("POSITION - UNREDACTED SENSITIVE DATA: Raw vehicle position data: %s", resp)
             if resp is not None:
                 redacted_lat = re.sub(r"\d", "#", str(resp["data"]["lat"]))
                 redacted_lon = re.sub(r"\d", "#", str(resp["data"]["lon"]))

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -599,7 +599,14 @@ class AudiConnectVehicle:
                 redacted_vin,
             )
             resp = await self._audi_service.get_stored_position(self._vehicle.vin)
-
+            # To enable detailed logging of raw vehicle position data for debugging purposes:
+            # 1. Remove the '#' from the start of the _LOGGER.debug line below.
+            # 2. Save the file.
+            # 3. Restart Home Assistant to apply the changes.
+            # Note: This will log sensitive data. To stop logging this data:
+            # 1. Add the '#' back at the start of the _LOGGER.debug line.
+            # 2. Save the file and restart Home Assistant again.
+            #_LOGGER.debug("POSITION - UNREDACTED SENSITIVE DATA: Raw vehicle position data: %s", resp)
             if resp is not None:
                 redacted_lat = re.sub(r"\d", "#", str(resp["data"]["lat"]))
                 redacted_lon = re.sub(r"\d", "#", str(resp["data"]["lon"]))


### PR DESCRIPTION
Instructions have been added to tell the user how to show raw unredacted GPS data in their logs. This will help with debugging so users can confirm if the issue is on the Audi API side, or the integration side.

In `custom_components/audiconnect/audi_connect_account.py` user can modify the commented out logger line to add the unredacted data to their logs. Below is the code block to look for:

```python
            # To enable detailed logging of raw vehicle position data for debugging purposes:
            # 1. Remove the '#' from the start of the _LOGGER.debug line below.
            # 2. Save the file.
            # 3. Restart Home Assistant to apply the changes.
            # Note: This will log sensitive data. To stop logging this data:
            # 1. Add the '#' back at the start of the _LOGGER.debug line.
            # 2. Save the file and restart Home Assistant again.
            #_LOGGER.debug("POSITION - UNREDACTED SENSITIVE DATA: Raw vehicle position data: %s", resp)
```