### PR TITLE
fix: Remove Charge Time Display for Gas Vehicles

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1640,7 +1640,7 @@ class AudiConnectVehicle:
     def remaining_charging_time(self):
         """Return remaining charging time"""
         if self.remaining_charging_time_supported:
-            return self._vehicle.state.get("remainingChargingTime")
+            return self._vehicle.state.get("remainingChargingTime", 0)
 
     @property
     def remaining_charging_time_unit(self):
@@ -1648,9 +1648,7 @@ class AudiConnectVehicle:
 
     @property
     def remaining_charging_time_supported(self):
-        check = self._vehicle.state.get("remainingChargingTime")
-        if check is not None:
-            return True
+        return self.car_type in ["hybrid", "electric"]
 
     @property
     def charging_complete_time(self):

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -606,7 +606,7 @@ class AudiConnectVehicle:
             # Note: This will log sensitive data. To stop logging this data:
             # 1. Add the '#' back at the start of the _LOGGER.debug line.
             # 2. Save the file and restart Home Assistant again.
-            #_LOGGER.debug("POSITION - UNREDACTED SENSITIVE DATA: Raw vehicle position data: %s", resp)
+            # _LOGGER.debug("POSITION - UNREDACTED SENSITIVE DATA: Raw vehicle position data: %s", resp)
             if resp is not None:
                 redacted_lat = re.sub(r"\d", "#", str(resp["data"]["lat"]))
                 redacted_lon = re.sub(r"\d", "#", str(resp["data"]["lon"]))

--- a/custom_components/audiconnect/audi_models.py
+++ b/custom_components/audiconnect/audi_models.py
@@ -268,13 +268,6 @@ class VehicleDataResponse:
         val = self._getFromJson(json, loc)
         # _LOGGER.debug("Initial value retrieved for '%s': %s", name, val)
 
-        # Special handling for remainingChargingTime
-        if name == "remainingChargingTime" and val is None:
-            val = 0
-            _LOGGER.debug(
-                "TRY APPEND STATE: 'remainingChargingTime' adjusted to 0 due to None value"
-            )
-
         if val is not None:
             loc[tsoff:] = ["carCapturedTimestamp"]
             # _LOGGER.debug("Updated loc for timestamp retrieval: %s", loc)


### PR DESCRIPTION
As discussed in #402 we need to check if `remaining_charging_time` is supported using a different method. Since the value only appears in the API output when a vehicle is actually charging, we need to check against car type first. If in a supported car type [hybrid,electric], then we want to return the value, if the value isn't available, then we want to return 0.

_Tested and working as expected with my 2021 Q5 plug-in hybrid. 
Hasn't been tested on a gas only vehicle to see if the respective sensors are removed._