### PR TITLE
fix: Support `roofCover`

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1229,6 +1229,7 @@ class AudiConnectVehicle:
         checkRightFront = self._vehicle.fields.get("STATE_RIGHT_FRONT_WINDOW")
         checkRightRear = self._vehicle.fields.get("STATE_RIGHT_REAR_WINDOW")
         checkSunRoof = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER", None)
+        checkRoofCover = self._vehicle.fields.get("STATE_ROOF_COVER_WINDOW", None)
         acceptable_window_states = ["3", "0", None]
         if (
             checkLeftFront
@@ -1236,6 +1237,7 @@ class AudiConnectVehicle:
             and checkRightFront
             and checkRightRear
             and (checkSunRoof in acceptable_window_states)
+            and (checkRoofCover in acceptable_window_states)
         ):
             return True
 
@@ -1247,6 +1249,7 @@ class AudiConnectVehicle:
             checkRightFront = self._vehicle.fields.get("STATE_RIGHT_FRONT_WINDOW")
             checkRightRear = self._vehicle.fields.get("STATE_RIGHT_REAR_WINDOW")
             checkSunRoof = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER", None)
+            checkRoofCover = self._vehicle.fields.get("STATE_ROOF_COVER_WINDOW", None)
             acceptable_window_states = ["3", None]
             return not (
                 checkLeftFront == "3"
@@ -1254,6 +1257,7 @@ class AudiConnectVehicle:
                 and checkRightFront == "3"
                 and checkRightRear == "3"
                 and (checkSunRoof in acceptable_window_states)
+                and (checkRoofCover in acceptable_window_states)
             )
 
     @property
@@ -1300,6 +1304,15 @@ class AudiConnectVehicle:
     def sun_roof(self):
         if self.sun_roof_supported:
             return self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER") != "3"
+
+    @property
+    def roof_cover_supported(self):
+        return self._vehicle.fields.get("STATE_ROOF_COVER_WINDOW")
+
+    @property
+    def roof_cover(self):
+        if self.roof_cover_supported:
+            return self._vehicle.fields.get("STATE_ROOF_COVER_WINDOW") != "3"
 
     @property
     def any_door_unlocked_supported(self):

--- a/custom_components/audiconnect/audi_models.py
+++ b/custom_components/audiconnect/audi_models.py
@@ -40,6 +40,7 @@ class VehicleDataResponse:
         "frontRightWindow": "STATE_RIGHT_FRONT_WINDOW",
         "rearLeftWindow": "STATE_LEFT_REAR_WINDOW",
         "rearRightWindow": "STATE_RIGHT_REAR_WINDOW",
+        "roofCoverWindow": "STATE_ROOF_COVER_WINDOW",
     }
 
     def __init__(self, data):

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -674,6 +674,11 @@ def create_instruments():
             device_class=BinarySensorDeviceClass.WINDOW,
         ),
         BinarySensor(
+            attr="roof_cover",
+            name="Roof Cover",
+            device_class=BinarySensorDeviceClass.WINDOW,
+        ),
+        BinarySensor(
             attr="parking_light",
             name="Parking light",
             device_class=BinarySensorDeviceClass.SAFETY,


### PR DESCRIPTION
Added support for `roofCover` as window as suggested in #359 .

### Testing
`roofCover` is unsupported for my vehicle. Results were as expected during testing:
 - The sensor is not shown in HA as the `roofCover` is listed as `unsupported` in my vehicle data response.
 - No other adverse effects were observed.

Further testing would be required by a user who has this data point available for their vehicle to confirm it is working as expected. As we don't know a user with this data point, I suggest reviewing/merging this PR and wait for feedback when available.
