### PR TITLE
fix: Logging: Redact Email Address & Easy (Un)Redact

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -113,7 +113,7 @@ async def async_setup_entry(hass, config_entry):
     _scan_active = config_entry.options.get(CONF_SCAN_ACTIVE, True)
     _LOGGER.debug("User option for CONF_SCAN_ACTIVE is %s.", _scan_active)
 
-    if REDACT_LOGS:
+    if config_entry.options.get(REDACT_LOGS, True):
         _LOGGER.debug("Redacting user logs...")
     else:
         _LOGGER.debug(

--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     MIN_UPDATE_INTERVAL,
     RESOURCES,
     COMPONENTS,
+    REDACT_LOGS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -111,6 +112,12 @@ async def async_setup_entry(hass, config_entry):
     # Get Active Scan Option - Default to True
     _scan_active = config_entry.options.get(CONF_SCAN_ACTIVE, True)
     _LOGGER.debug("User option for CONF_SCAN_ACTIVE is %s.", _scan_active)
+
+    if REDACT_LOGS:
+        _LOGGER.debug("Redacting user logs...")
+    else:
+        _LOGGER.debug("User logs will not be redacted. Sensitive data may be visible...")
+
 
     account = config_entry.data.get(CONF_USERNAME)
 

--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -116,8 +116,9 @@ async def async_setup_entry(hass, config_entry):
     if REDACT_LOGS:
         _LOGGER.debug("Redacting user logs...")
     else:
-        _LOGGER.debug("User logs will not be redacted. Sensitive data may be visible...")
-
+        _LOGGER.debug(
+            "User logs will not be redacted. Sensitive data may be visible..."
+        )
 
     account = config_entry.data.get(CONF_USERNAME)
 

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 from .dashboard import Dashboard
 from .audi_connect_account import AudiConnectAccount, AudiConnectObserver
 from .audi_models import VehicleData
+from .util import log_vin
 
 from .const import (
     DOMAIN,
@@ -34,7 +35,6 @@ from .const import (
     TRACKER_UPDATE,
     COMPONENTS,
     UPDATE_SLEEP,
-    REDACT_LOGS,
 )
 
 REFRESH_VEHICLE_DATA_FAILED_EVENT = "refresh_failed"
@@ -258,7 +258,7 @@ class AudiAccount(AudiConnectObserver):
         await self._refresh_vehicle_data(vin)
 
     async def _refresh_vehicle_data(self, vin):
-        log_vin = "*" * (len(vin) - 4) + vin[-4:] if REDACT_LOGS else vin
+        log_vin = log_vin(vin)
         res = await self.connection.refresh_vehicle_data(vin)
 
         if res is True:

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1232,6 +1232,7 @@ class AudiConnectVehicle:
         checkRightFront = self._vehicle.fields.get("STATE_RIGHT_FRONT_WINDOW")
         checkRightRear = self._vehicle.fields.get("STATE_RIGHT_REAR_WINDOW")
         checkSunRoof = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER", None)
+        checkRoofCover = self._vehicle.fields.get("STATE_ROOF_COVER_WINDOW", None)
         acceptable_window_states = ["3", "0", None]
         if (
             checkLeftFront
@@ -1239,6 +1240,7 @@ class AudiConnectVehicle:
             and checkRightFront
             and checkRightRear
             and (checkSunRoof in acceptable_window_states)
+            and (checkRoofCover in acceptable_window_states)
         ):
             return True
 
@@ -1250,6 +1252,7 @@ class AudiConnectVehicle:
             checkRightFront = self._vehicle.fields.get("STATE_RIGHT_FRONT_WINDOW")
             checkRightRear = self._vehicle.fields.get("STATE_RIGHT_REAR_WINDOW")
             checkSunRoof = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER", None)
+            checkRoofCover = self._vehicle.fields.get("STATE_ROOF_COVER_WINDOW", None)
             acceptable_window_states = ["3", None]
             return not (
                 checkLeftFront == "3"
@@ -1257,6 +1260,7 @@ class AudiConnectVehicle:
                 and checkRightFront == "3"
                 and checkRightRear == "3"
                 and (checkSunRoof in acceptable_window_states)
+                and (checkRoofCover in acceptable_window_states)
             )
 
     @property
@@ -1303,6 +1307,15 @@ class AudiConnectVehicle:
     def sun_roof(self):
         if self.sun_roof_supported:
             return self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER") != "3"
+
+    @property
+    def roof_cover_supported(self):
+        return self._vehicle.fields.get("STATE_ROOF_COVER_WINDOW")
+
+    @property
+    def roof_cover(self):
+        if self.roof_cover_supported:
+            return self._vehicle.fields.get("STATE_ROOF_COVER_WINDOW") != "3"
 
     @property
     def any_door_unlocked_supported(self):

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -581,10 +581,12 @@ class AudiConnectVehicle:
             )
 
     async def update_vehicle_position(self):
-        log_vin = "*" * (len(self._vehicle.vin) - 4) + self._vehicle.vin[-4:] if REDACT_LOGS else self._vehicle.vin
-        _LOGGER.debug(
-            "POSITION: Starting update_vehicle_position for VIN: %s", log_vin
+        log_vin = (
+            "*" * (len(self._vehicle.vin) - 4) + self._vehicle.vin[-4:]
+            if REDACT_LOGS
+            else self._vehicle.vin
         )
+        _LOGGER.debug("POSITION: Starting update_vehicle_position for VIN: %s", log_vin)
 
         if not self.support_position:
             _LOGGER.debug(
@@ -630,7 +632,6 @@ class AudiConnectVehicle:
                         log_vin,
                         resp,
                     )
-                    
 
                 self._vehicle.state["position"] = {
                     "latitude": resp["data"]["lat"],
@@ -684,7 +685,11 @@ class AudiConnectVehicle:
             )
 
     async def update_vehicle_climater(self):
-        log_vin = "*" * (len(self._vehicle.vin) - 4) + self._vehicle.vin[-4:] if REDACT_LOGS else self._vehicle.vin
+        log_vin = (
+            "*" * (len(self._vehicle.vin) - 4) + self._vehicle.vin[-4:]
+            if REDACT_LOGS
+            else self._vehicle.vin
+        )
         if not self.support_climater:
             return
 
@@ -920,7 +925,11 @@ class AudiConnectVehicle:
         await self.update_vehicle_tripdata("shortTerm")
 
     async def update_vehicle_tripdata(self, kind: str):
-        log_vin = "*" * (len(self._vehicle.vin) - 4) + self._vehicle.vin[-4:] if REDACT_LOGS else self._vehicle.vin
+        log_vin = (
+            "*" * (len(self._vehicle.vin) - 4) + self._vehicle.vin[-4:]
+            if REDACT_LOGS
+            else self._vehicle.vin
+        )
         if not self.support_trip_data:
             _LOGGER.debug(
                 "Trip data support is disabled for VIN: %s. Exiting update process.",

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -12,7 +12,14 @@ from abc import ABC, abstractmethod
 
 from .audi_services import AudiService
 from .audi_api import AudiAPI
-from .util import log_exception, get_attr, parse_int, parse_float, parse_datetime, log_vin
+from .util import (
+    log_exception,
+    get_attr,
+    parse_int,
+    parse_float,
+    parse_datetime,
+    log_vin,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -14,6 +14,7 @@ from .audi_models import (
 )
 from .audi_api import AudiAPI
 from .util import to_byte_array, get_attr
+from .const import REDACT_LOGS
 
 from hashlib import sha256, sha512
 import hmac
@@ -161,7 +162,7 @@ class AudiService:
         )
 
     async def get_stored_vehicle_data(self, vin: str):
-        redacted_vin = "*" * (len(vin) - 4) + vin[-4:]
+        log_vin = "*" * (len(vin) - 4) + vin[-4:] if REDACT_LOGS else vin
         JOBS2QUERY = {
             "access",
             "activeVentilation",
@@ -195,7 +196,7 @@ class AudiService:
                 jobs=",".join(JOBS2QUERY),
             )
         )
-        _LOGGER.debug("Vehicle data returned for VIN: %s: %s", redacted_vin, data)
+        _LOGGER.debug("Vehicle data returned for VIN: %s: %s", log_vin, data)
         return VehicleDataResponse(data)
 
     async def get_charger(self, vin: str):

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -14,7 +14,6 @@ from .audi_models import (
 )
 from .audi_api import AudiAPI
 from .util import to_byte_array, get_attr, log_vin
-from .const import REDACT_LOGS
 
 from hashlib import sha256, sha512
 import hmac

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -13,7 +13,7 @@ from .audi_models import (
     VehiclesResponse,
 )
 from .audi_api import AudiAPI
-from .util import to_byte_array, get_attr
+from .util import to_byte_array, get_attr, log_vin
 from .const import REDACT_LOGS
 
 from hashlib import sha256, sha512
@@ -162,7 +162,7 @@ class AudiService:
         )
 
     async def get_stored_vehicle_data(self, vin: str):
-        log_vin = "*" * (len(vin) - 4) + vin[-4:] if REDACT_LOGS else vin
+        log_vin = log_vin(vin)
         JOBS2QUERY = {
             "access",
             "activeVentilation",

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -167,9 +167,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
         self.config_entry: config_entries.ConfigEntry = config_entry
         log_account = log_account_email(config_entry.title)
-        _LOGGER.debug(
-            "Initializing options flow for audiconnect: %s", log_account
-        )
+        _LOGGER.debug("Initializing options flow for audiconnect: %s", log_account)
 
     async def async_step_init(self, user_input=None):
         log_account = log_account_email(self.config_entry.title)

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -194,11 +194,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         )
 
         _LOGGER.debug(
-            "Preparing options form for %s with default scan interval: %s minutes, initial scan: %s, active scan: %s",
+            "Preparing options form for %s with scan interval: %s minutes, initial scan: %s, active scan: %s, redact logs: %s",
             log_account,
             current_scan_interval,
             self.config_entry.options.get(CONF_SCAN_INITIAL, True),
             self.config_entry.options.get(CONF_SCAN_ACTIVE, True),
+            self.config_entry.options.get(REDACT_LOGS, True),
         )
 
         return self.async_show_form(
@@ -216,6 +217,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_SCAN_INTERVAL, default=current_scan_interval
                     ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_UPDATE_INTERVAL)),
+                    vol.Required(
+                        REDACT_LOGS,
+                        default=self.config_entry.options.get(REDACT_LOGS, True),
+                    ): bool,
                 }
             ),
         )

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     MIN_UPDATE_INTERVAL,
     CONF_SCAN_INITIAL,
     CONF_SCAN_ACTIVE,
+    REDACT_LOGS,
 )
 from .util import log_account_email
 

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_SCAN_INITIAL,
     CONF_SCAN_ACTIVE,
 )
+from .util import log_account_email
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -140,7 +141,8 @@ class AudiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 raise Exception("Unexpected error communicating with the Audi server")
 
         except Exception:
-            _LOGGER.error("Invalid credentials for %s", username)
+            log_account = log_account_email(username)
+            _LOGGER.error("Invalid credentials for %s", log_account)
             return self.async_abort(reason="invalid_credentials")
 
         return self.async_create_entry(
@@ -164,31 +166,38 @@ class AudiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
         self.config_entry: config_entries.ConfigEntry = config_entry
+        log_account = log_account_email(config_entry.title)
         _LOGGER.debug(
-            "Initializing options flow for audiconnect: %s", config_entry.title
+            "Initializing options flow for audiconnect: %s", log_account
         )
 
     async def async_step_init(self, user_input=None):
+        log_account = log_account_email(self.config_entry.title)
         _LOGGER.debug(
-            "Options flow initiated for audiconnect: %s", self.config_entry.title
+            "Options flow initiated for audiconnect: %s",
+            log_account,
         )
         if user_input is not None:
-            _LOGGER.info("Received user input for options: %s", user_input)
+            _LOGGER.debug(
+                "Received user input for audiconnect %s options: %s",
+                log_account,
+                user_input,
+            )
             return self.async_create_entry(title="", data=user_input)
 
         current_scan_interval = self.config_entry.options.get(
             CONF_SCAN_INTERVAL,
             self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
         )
-        _LOGGER.info(
+        _LOGGER.debug(
             "Retrieved current scan interval for audiconnect %s: %s minutes",
-            self.config_entry.title,
+            log_account,
             current_scan_interval,
         )
 
         _LOGGER.debug(
             "Preparing options form for %s with default scan interval: %s minutes, initial scan: %s, active scan: %s",
-            self.config_entry.title,
+            log_account,
             current_scan_interval,
             self.config_entry.options.get(CONF_SCAN_INITIAL, True),
             self.config_entry.options.get(CONF_SCAN_ACTIVE, True),

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -16,6 +16,8 @@ CONF_SCAN_ACTIVE = "scan_active"
 MIN_UPDATE_INTERVAL = 15
 DEFAULT_UPDATE_INTERVAL = 15
 UPDATE_SLEEP = 5
+# Set REDACT_LOGS to False to view unredacted logs, or True to keep logs redacted.
+REDACT_LOGS = True
 
 CONF_SPIN = "spin"
 CONF_REGION = "region"

--- a/custom_components/audiconnect/util.py
+++ b/custom_components/audiconnect/util.py
@@ -57,13 +57,16 @@ def parse_datetime(time_value):
                 continue
     return None
 
+
 def log_account_email(email):
     if "@" not in email:
         return email
     if REDACT_LOGS:
         local_part, domain = email.split("@")
         if len(local_part) > 2:
-            redacted_local = local_part[0] + "*" * (len(local_part) - 2) + local_part[-1]
+            redacted_local = (
+                local_part[0] + "*" * (len(local_part) - 2) + local_part[-1]
+            )
         else:
             redacted_local = local_part[0] + "*" * (len(local_part) - 1)
         return redacted_local + "@" + domain

--- a/custom_components/audiconnect/util.py
+++ b/custom_components/audiconnect/util.py
@@ -1,5 +1,6 @@
 from functools import reduce
 from datetime import datetime, timezone
+from .const import REDACT_LOGS
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,3 +56,16 @@ def parse_datetime(time_value):
             except ValueError:
                 continue
     return None
+
+def log_account_email(email):
+    if "@" not in email:
+        return email
+    if REDACT_LOGS:
+        local_part, domain = email.split("@")
+        if len(local_part) > 2:
+            redacted_local = local_part[0] + "*" * (len(local_part) - 2) + local_part[-1]
+        else:
+            redacted_local = local_part[0] + "*" * (len(local_part) - 1)
+        return redacted_local + "@" + domain
+    else:
+        return email

--- a/custom_components/audiconnect/util.py
+++ b/custom_components/audiconnect/util.py
@@ -59,6 +59,7 @@ def parse_datetime(time_value):
 
 
 def log_account_email(email):
+    """Redacts users account email address from logs based on user option REDACT_LOGS"""
     if "@" not in email:
         return email
     if REDACT_LOGS:
@@ -72,3 +73,11 @@ def log_account_email(email):
         return redacted_local + "@" + domain
     else:
         return email
+
+
+def log_vin(vin):
+    """Redacts vehicle vin from logs based on user option REDACT_LOGS"""
+    if REDACT_LOGS:
+        return "*" * (len(vin) - 4) + vin[-4:]
+    else:
+        return vin


### PR DESCRIPTION
- Redacts email address in the logs for initial setup and options flow handler.
- Also simplifies the process for controlling log redaction. Users can now toggle log redaction by setting `REDACT_LOGS` in `const.py` to `False` and restart Home Assistant. To enable redaction again, simply set `REDACT_LOGS` back to `True` and restart Home Assistant.