### PR TITLE
chore: Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Gets semantic release info
         id: semantic_release_info
-        uses: jossef/action-semantic-release-info@v2
+        uses: jossef/action-semantic-release-info@v3.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Update Version and Commit
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{steps.semantic_release_info.outputs.version != ''}}
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.14.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{steps.semantic_release_info.outputs.version != ''}}
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Prevent message from action "Release":

> [build](https://github.com/audiconnect/audi_connect_ha/actions/runs/9092268770/job/24988619333)
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: jossef/action-semantic-release-info@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Changelog: https://github.com/jossef/action-semantic-release-info/compare/v2...v3.0.0