### PR TITLE
fix: Disable Services w/ 404 Error

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,5 +32,5 @@ Disable Debug Logging
 **Your Vehicle Details**
 Model:
 Year:
-Type (Combustion/Hybrid/Electric):
+Type (Gas/Hybrid/Electric):
 Region (EU/US/CA/CN):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,4 +33,4 @@ Disable Debug Logging
 Model:
 Year:
 Type (ICE/PHEV/BEV):
-Region (EU/US/CA/CN): 
+Region (EU/US/CA/CN):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,5 +32,5 @@ Disable Debug Logging
 **Your Vehicle Details**
 Model:
 Year:
-Type (ICE/PHEV/BEV):
+Type (Combustion/Hybrid/Electric):
 Region (EU/US/CA/CN):

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -751,7 +751,7 @@ class AudiConnectVehicle:
         except ClientResponseError as cre:
             if cre.status in (403, 404, 502):
                 _LOGGER.debug(
-                    "ClientResponseError with status %s while updating climater for VIN: %s. Disabling climater support.",
+                    "CLIMATER: ClientResponseError with status %s while updating climater for VIN: %s. Disabling climater support.",
                     cre.status,
                     redacted_vin,
                 )

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -183,7 +183,7 @@ class AudiConnectAccount:
             )
             return False
         except ClientResponseError as cre:
-            if cre.status in (403, 502):
+            if cre.status in (403, 404, 502):
                 _LOGGER.debug(
                     "ClientResponseError with status %s while refreshing vehicle data for VIN: %s. Disabling refresh vehicle data support.",
                     cre.status,
@@ -562,7 +562,7 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
-            if resp_exception.status in (403, 502):
+            if resp_exception.status in (403, 404, 502):
                 self.support_status_report = False
             else:
                 self.log_exception_once(
@@ -656,7 +656,7 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 502):
+            if cre.status in (403, 404, 502):
                 _LOGGER.error(
                     "POSITION: ClientResponseError with status %s for VIN: %s. Disabling vehicle position support.",
                     cre.status,
@@ -749,7 +749,7 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 502):
+            if cre.status in (403, 404, 502):
                 _LOGGER.debug(
                     "ClientResponseError with status %s while updating climater for VIN: %s. Disabling climater support.",
                     cre.status,
@@ -791,7 +791,7 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
-            if resp_exception.status == 403 or resp_exception.status == 502:
+            if resp_exception.status in (403, 404, 502):
                 # _LOGGER.error(
                 #    "support_preheater set to False: {status}".format(
                 #        status=resp_exception.status
@@ -891,7 +891,7 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
-            if resp_exception.status == 403 or resp_exception.status == 502:
+            if resp_exception.status in (403, 404, 502):
                 # _LOGGER.error(
                 #    "support_charger set to False: {status}".format(
                 #        status=resp_exception.status
@@ -963,7 +963,7 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 502):
+            if cre.status in (403, 404, 502):
                 _LOGGER.debug(
                     "ClientResponseError with status %s while updating trip data for VIN: %s. Disabling trip data support.",
                     cre.status,

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -183,7 +183,7 @@ class AudiConnectAccount:
             )
             return False
         except ClientResponseError as cre:
-            if cre.status in (403, 404, 502):
+            if cre.status in (403, 404):
                 _LOGGER.debug(
                     "ClientResponseError with status %s while refreshing vehicle data for VIN: %s. Disabling refresh vehicle data support.",
                     cre.status,
@@ -562,7 +562,7 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
-            if resp_exception.status in (403, 404, 502):
+            if resp_exception.status in (403, 404):
                 self.support_status_report = False
             else:
                 self.log_exception_once(
@@ -656,7 +656,7 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404, 502):
+            if cre.status in (403, 404):
                 _LOGGER.error(
                     "POSITION: ClientResponseError with status %s for VIN: %s. Disabling vehicle position support.",
                     cre.status,
@@ -749,7 +749,7 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404, 502):
+            if cre.status in (403, 404):
                 _LOGGER.debug(
                     "CLIMATER: ClientResponseError with status %s while updating climater for VIN: %s. Disabling climater support.",
                     cre.status,
@@ -791,7 +791,7 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
-            if resp_exception.status in (403, 404, 502):
+            if resp_exception.status in (403, 404):
                 # _LOGGER.error(
                 #    "support_preheater set to False: {status}".format(
                 #        status=resp_exception.status
@@ -891,7 +891,7 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
-            if resp_exception.status in (403, 404, 502):
+            if resp_exception.status in (403, 404):
                 # _LOGGER.error(
                 #    "support_charger set to False: {status}".format(
                 #        status=resp_exception.status
@@ -963,7 +963,7 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404, 502):
+            if cre.status in (403, 404):
                 _LOGGER.debug(
                     "ClientResponseError with status %s while updating trip data for VIN: %s. Disabling trip data support.",
                     cre.status,


### PR DESCRIPTION
We should disable services that return a 404 error. This will decrease the number of polling errors if an endpoint is dead.

Additional Note: Do we really want 502 to disable services? Couldn't a bad gateway be temporary? This could be the reason GPS locations aren't consistently updated over time until an HA reboot?