### PR TITLE
fix: async_timeout preventing login

### DIFF
--- a/custom_components/audiconnect/audi_api.py
+++ b/custom_components/audiconnect/audi_api.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import datetime
 
-import async_timeout
+import asyncio
 
 from asyncio import TimeoutError, CancelledError
 from aiohttp import ClientResponseError
@@ -46,7 +46,7 @@ class AudiAPI:
         **kwargs,
     ):
         try:
-            with async_timeout.timeout(TIMEOUT):
+            async with asyncio.timeout(TIMEOUT):
                 async with self._session.request(
                     method, url, headers=headers, data=data, **kwargs
                 ) as response:


### PR DESCRIPTION
Fixes #488

It seems the async_timeout is banned and caused issues anyway, so switching to asyncio seems to work well. Login is possible after this fix and following errors should be gone:

```
Logger: custom_components.audiconnect.audi_connect_account
Quelle: custom_components/audiconnect/audi_connect_account.py:90
Integration: Audi Connect (Dokumentation, Probleme)
Erstmals aufgetreten: 2. November 2024 um 20:10:23 (106 Vorkommnisse)
Zuletzt protokolliert: 09:18:47

LOGIN: Login to Audi service failed: 'Timeout' object does not support the context manager protocol
```