### PR TITLE
fix: Adjust polling interval if car is being charged and is an e-tron

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -127,10 +127,14 @@ async def async_setup_entry(hass, config_entry):
 
         # Check if the car is being charged and is an e-tron
         if data.is_charging_and_etron():
-            _LOGGER.debug("Car is being charged and is an e-tron. Adjusting polling interval to 30 seconds.")
+            _LOGGER.debug(
+                "Car is being charged and is an e-tron. Adjusting polling interval to 30 seconds."
+            )
             polling_interval = timedelta(seconds=30)
         else:
-            _LOGGER.debug("Car is not being charged or is not an e-tron. Using default polling interval.")
+            _LOGGER.debug(
+                "Car is not being charged or is not an e-tron. Using default polling interval."
+            )
             polling_interval = scan_interval
 
         await data.update(utcnow())

--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -124,7 +124,19 @@ async def async_setup_entry(hass, config_entry):
     async def update_data(now):
         """Update the data with the latest information."""
         _LOGGER.debug("ACTIVE POLLING: Requesting scheduled cloud data refresh...")
+
+        # Check if the car is being charged and is an e-tron
+        if data.is_charging_and_etron():
+            _LOGGER.debug("Car is being charged and is an e-tron. Adjusting polling interval to 30 seconds.")
+            polling_interval = timedelta(seconds=30)
+        else:
+            _LOGGER.debug("Car is not being charged or is not an e-tron. Using default polling interval.")
+            polling_interval = scan_interval
+
         await data.update(utcnow())
+
+        # Schedule the next update based on the polling interval
+        async_track_time_interval(hass, update_data, polling_interval)
 
     # Schedule the update_data function if option is true
     if _scan_active:

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -264,3 +264,11 @@ class AudiAccount(AudiConnectObserver):
             await self.update(utcnow())
         except Exception as e:
             _LOGGER.exception("Refresh cloud data failed: %s", str(e))
+
+    def is_charging_and_etron(self):
+        for vehicle in self.config_vehicles:
+            if vehicle.vehicle.model_family.lower() == "etron":
+                charging_state = vehicle.vehicle.state.get("chargingState")
+                if charging_state and float(charging_state) > 0:
+                    return True
+        return False


### PR DESCRIPTION
Add a condition to check if the car is being charged and is an e-tron to adjust the polling interval to 30 seconds.

* Modify `custom_components/audiconnect/__init__.py` to include the new condition and adjust the polling interval accordingly.
* Add a method in `custom_components/audiconnect/audi_account.py` to check if the car is being charged and is an e-tron, returning a boolean value based on the condition.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/audiconnect/audi_connect_ha/pull/503?shareId=9396cd62-72d1-4551-b38a-d57cb53e7154).