### PR TITLE
feat: is_moving sensor indicates if the vehicle is used

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -646,6 +646,8 @@ class AudiConnectVehicle:
                     "parktime": parktime,
                 }
 
+                self._vehicle.state['is_moving'] = False
+
                 _LOGGER.debug(
                     "POSITION: Vehicle position updated successfully for VIN: %s",
                     redacted_vin,
@@ -685,9 +687,12 @@ class AudiConnectVehicle:
                 )
             else:
                 _LOGGER.debug(
-                    "POSITION: Vehicle position currently not available for VIN: %s. Received 204 status.",
+                    "POSITION: Vehicle position currently not available for VIN: %s (Is moving?!). Received 204 status.",
                     redacted_vin,
                 )
+                # we receive a 204 when the vehicle is moving.
+                self._vehicle.state['is_moving'] = True
+
 
         except Exception as e:
             _LOGGER.error(
@@ -1915,3 +1920,14 @@ class AudiConnectVehicle:
         check = self._vehicle.state.get("longterm_reset")
         if check:
             return True
+
+    @property
+    def is_moving(self):
+        """Return true if the vehicle is moving."""
+        if self.is_moving_supported:
+            return self._vehicle.state.get("is_moving")
+
+    @property
+    def is_moving_supported(self):
+        """Return true if vehicle can move."""
+        return True

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -646,7 +646,7 @@ class AudiConnectVehicle:
                     "parktime": parktime,
                 }
 
-                self._vehicle.state['is_moving'] = False
+                self._vehicle.state["is_moving"] = False
 
                 _LOGGER.debug(
                     "POSITION: Vehicle position updated successfully for VIN: %s",
@@ -691,8 +691,7 @@ class AudiConnectVehicle:
                     redacted_vin,
                 )
                 # we receive a 204 when the vehicle is moving.
-                self._vehicle.state['is_moving'] = True
-
+                self._vehicle.state["is_moving"] = True
 
         except Exception as e:
             _LOGGER.error(

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -68,6 +68,7 @@ RESOURCES = [
     "left_rear_window_open",
     "right_rear_window_open",
     "braking_status",
+    "is_moving",
 ]
 
 COMPONENTS = {

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -776,6 +776,13 @@ def create_instruments():
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
+        BinarySensor(
+            attr="is_moving",
+            name="Is moving",
+            icon="mdi:motion-outline",
+            device_class=BinarySensorDeviceClass.MOTION,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
     ]
 
 


### PR DESCRIPTION
The Audi connect API returns a 204 HTTP code, when the vehicle is in use.
This PR is using this, to update a `is_moving`  binary sensor to indicate the motion of the car. 
If the vehicle is used, the other values aren't updated. So the information is essential.

Changes:

- custom_components/audiconnect/const.py
  - `is_moving` has been added to the RESOURCES list
- custom_components/audiconnect/dashboard.py
  - The new binary sensor `is moving` has been added.
-  custom_components/audiconnect/audi_connect_account.py
   - added the functions to add the new sensor to the dashboard
   -  set is_moving to true when receiving a HTTP 204 on the position API call.
   -  reset it to false, when receiving a successful position update.  