### PR TITLE
feat: `Debug Logs` Option

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -103,16 +103,18 @@ async def async_update_listener(hass, config_entry):
 async def async_setup_entry(hass, config_entry):
     """Set up this integration using UI."""
     _LOGGER.debug("Audi Connect starting...")
-    
+
     # Set logger level initially based on config options.
     if config_entry.options.get(CONF_DEBUG_LOGS, False):
         logging.getLogger(DOMAIN).setLevel(logging.DEBUG)
     else:
         logging.getLogger(DOMAIN).setLevel(logging.INFO)
-    
+
     # Register the update listener so that changes to options are applied immediately.
-    config_entry.async_on_unload(config_entry.add_update_listener(async_update_listener))
-    
+    config_entry.async_on_unload(
+        config_entry.add_update_listener(async_update_listener)
+    )
+
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
 

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -70,7 +70,7 @@ PLATFORMS: list[str] = [
 
 SERVICE_REFRESH_CLOUD_DATA = "refresh_cloud_data"
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 class AudiAccount(AudiConnectObserver):
@@ -208,7 +208,7 @@ class AudiAccount(AudiConnectObserver):
             await self.connection.set_vehicle_window_heating(vin, False)
 
     async def start_climate_control(self, service):
-        _LOGGER.info("Initiating Start Climate Control Service...")
+        _LOGGER.debug("Initiating Start Climate Control Service...")
         vin = service.data.get(CONF_VIN).lower()
         # Optional Parameters
         temp_f = service.data.get(CONF_CLIMATE_TEMP_F, None)

--- a/custom_components/audiconnect/audi_api.py
+++ b/custom_components/audiconnect/audi_api.py
@@ -12,6 +12,7 @@ from typing import Dict
 
 TIMEOUT = 30
 from .const import DOMAIN
+
 _LOGGER = logging.getLogger(DOMAIN)
 
 

--- a/custom_components/audiconnect/audi_api.py
+++ b/custom_components/audiconnect/audi_api.py
@@ -11,8 +11,8 @@ from aiohttp.hdrs import METH_GET, METH_POST, METH_PUT
 from typing import Dict
 
 TIMEOUT = 30
-
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 class AudiAPI:

--- a/custom_components/audiconnect/audi_api.py
+++ b/custom_components/audiconnect/audi_api.py
@@ -9,9 +9,9 @@ from aiohttp import ClientResponseError
 from aiohttp.hdrs import METH_GET, METH_POST, METH_PUT
 
 from typing import Dict
+from .const import DOMAIN
 
 TIMEOUT = 30
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(DOMAIN)
 

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -15,6 +15,7 @@ from .audi_api import AudiAPI
 from .util import log_exception, get_attr, parse_int, parse_float, parse_datetime
 
 from .const import DOMAIN
+
 _LOGGER = logging.getLogger(DOMAIN)
 
 MAX_RESPONSE_ATTEMPTS = 10

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -14,7 +14,8 @@ from .audi_services import AudiService
 from .audi_api import AudiAPI
 from .util import log_exception, get_attr, parse_int, parse_float, parse_datetime
 
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN
+_LOGGER = logging.getLogger(DOMAIN)
 
 MAX_RESPONSE_ATTEMPTS = 10
 REQUEST_STATUS_SLEEP = 5

--- a/custom_components/audiconnect/audi_models.py
+++ b/custom_components/audiconnect/audi_models.py
@@ -2,6 +2,7 @@ import logging
 from .util import get_attr
 
 from .const import DOMAIN
+
 _LOGGER = logging.getLogger(DOMAIN)
 
 

--- a/custom_components/audiconnect/audi_models.py
+++ b/custom_components/audiconnect/audi_models.py
@@ -1,7 +1,8 @@
 import logging
 from .util import get_attr
 
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 class VehicleData:

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -26,7 +26,7 @@ from bs4 import BeautifulSoup
 from requests import RequestException
 
 from typing import Dict
-
+from .const import DOMAIN
 
 MAX_RESPONSE_ATTEMPTS = 10
 REQUEST_STATUS_SLEEP = 10
@@ -36,7 +36,7 @@ FAILED = "failed"
 REQUEST_SUCCESSFUL = "request_successful"
 REQUEST_FAILED = "request_failed"
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 class BrowserLoginResponse:

--- a/custom_components/audiconnect/binary_sensor.py
+++ b/custom_components/audiconnect/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_USERNAME
 from .audi_entity import AudiEntity
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -20,10 +20,11 @@ from .const import (
     MIN_UPDATE_INTERVAL,
     CONF_SCAN_INITIAL,
     CONF_SCAN_ACTIVE,
+    CONF_DEBUG_LOGS,
     REGIONS,
 )
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 @callback
@@ -174,14 +175,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             "Options flow initiated for audiconnect: %s", self._config_entry.title
         )
         if user_input is not None:
-            _LOGGER.info("Received user input for options: %s", user_input)
+            _LOGGER.debug("Received user input for options: %s", user_input)
             return self.async_create_entry(title="", data=user_input)
 
         current_scan_interval = self._config_entry.options.get(
             CONF_SCAN_INTERVAL,
             self._config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
         )
-        _LOGGER.info(
+        _LOGGER.debug(
             "Retrieved current scan interval for audiconnect %s: %s minutes",
             self._config_entry.title,
             current_scan_interval,
@@ -210,6 +211,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_SCAN_INTERVAL, default=current_scan_interval
                     ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_UPDATE_INTERVAL)),
+                    vol.Optional(CONF_DEBUG_LOGS, default=self._config_entry.options.get(CONF_DEBUG_LOGS, False)): bool,
                 }
             ),
         )

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -211,7 +211,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_SCAN_INTERVAL, default=current_scan_interval
                     ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_UPDATE_INTERVAL)),
-                    vol.Optional(CONF_DEBUG_LOGS, default=self._config_entry.options.get(CONF_DEBUG_LOGS, False)): bool,
+                    vol.Optional(
+                        CONF_DEBUG_LOGS,
+                        default=self._config_entry.options.get(CONF_DEBUG_LOGS, False),
+                    ): bool,
                 }
             ),
         )

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -10,6 +10,7 @@ CONF_CLIMATE_SEAT_FL = "seat_fl"
 CONF_CLIMATE_SEAT_FR = "seat_fr"
 CONF_CLIMATE_SEAT_RL = "seat_rl"
 CONF_CLIMATE_SEAT_RR = "seat_rr"
+CONF_DEBUG_LOGS = "debug"
 CONF_SCAN_INITIAL = "scan_initial"
 CONF_SCAN_ACTIVE = "scan_active"
 

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
 )
 from .util import parse_datetime
 from .const import DOMAIN
+
 _LOGGER = logging.getLogger(DOMAIN)
 
 

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -18,8 +18,8 @@ from homeassistant.const import (
     EntityCategory,
 )
 from .util import parse_datetime
-
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 class Instrument:
@@ -50,7 +50,7 @@ class Instrument:
         self._vehicle = vehicle
 
         if not mutable and self.is_mutable:
-            _LOGGER.info("Skipping %s because mutable", self)
+            _LOGGER.debug("Skipping %s because mutable", self)
             return False
 
         if not self.is_supported:

--- a/custom_components/audiconnect/device_tracker.py
+++ b/custom_components/audiconnect/device_tracker.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_USERNAME
 
 from .const import DOMAIN, TRACKER_UPDATE
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 async def async_setup_scanner(hass, config, async_see, discovery_info=None):

--- a/custom_components/audiconnect/lock.py
+++ b/custom_components/audiconnect/lock.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_USERNAME
 from .audi_entity import AudiEntity
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_USERNAME
 from .audi_entity import AudiEntity
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -30,13 +30,15 @@
         "data": {
           "scan_initial": "Cloud Update at Startup",
           "scan_active": "Active Polling at Scan Interval",
-          "scan_interval": "Scan Interval"
+          "scan_interval": "Scan Interval",
+          "debug": "Debug Logs"
         },
         "title": "Audi Connect Options",
         "data_description": {
           "scan_initial": "Perform a cloud update immediately upon startup.",
           "scan_active": "Perform a cloud update at the set scan interval.",
-          "scan_interval": "Minutes between active polling. If 'Active Polling at Scan Interval' is off, this value will have no impact."
+          "scan_interval": "Minutes between active polling. If 'Active Polling at Scan Interval' is off, this value will have no impact.",
+          "debug": "Turns on DEBUG level logging."
         }
       }
     }
@@ -54,8 +56,7 @@
         "start_preheater": "Start Preheater",
         "stop_preheater": "Stop Preheater",
         "start_window_heating": "Start Window heating",
-        "stop_window_heating": "Stop Windows heating",
-        "is_moving": "Is moving"
+        "stop_window_heating": "Stop Windows heating"
       }
     }
   },

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -56,7 +56,8 @@
         "start_preheater": "Start Preheater",
         "stop_preheater": "Stop Preheater",
         "start_window_heating": "Start Window heating",
-        "stop_window_heating": "Stop Windows heating"
+        "stop_window_heating": "Stop Windows heating",
+        "is_moving": "Is moving"
       }
     }
   },

--- a/custom_components/audiconnect/switch.py
+++ b/custom_components/audiconnect/switch.py
@@ -8,7 +8,7 @@ from homeassistant.const import CONF_USERNAME
 from .audi_entity import AudiEntity
 from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -30,13 +30,15 @@
         "data": {
           "scan_initial": "Cloud Update at Startup",
           "scan_active": "Active Polling at Scan Interval",
-          "scan_interval": "Scan Interval"
+          "scan_interval": "Scan Interval",
+          "debug": "Debug Logs"
         },
         "title": "Audi Connect Options",
         "data_description": {
           "scan_initial": "Perform a cloud update immediately upon startup.",
           "scan_active": "Perform a cloud update at the set scan interval.",
-          "scan_interval": "Minutes between active polling. If 'Active Polling at Scan Interval' is off, this value will have no impact."
+          "scan_interval": "Minutes between active polling. If 'Active Polling at Scan Interval' is off, this value will have no impact.",
+          "debug": "Turns on DEBUG level logging."
         }
       }
     }

--- a/custom_components/audiconnect/util.py
+++ b/custom_components/audiconnect/util.py
@@ -1,8 +1,9 @@
 from functools import reduce
 from datetime import datetime, timezone
 import logging
+from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(DOMAIN)
 
 
 def get_attr(dictionary, keys, default=None):

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Find configuration options under **Settings ➤ Devices & Services ➤ Integrati
 - **Cloud Update at Startup (`bool`)**: Toggle cloud updates at integration startup. Ideal for development or frequent HA restarts.
 - **Active Polling at Scan Interval (`bool`)**: Enable or disable active polling.
 - **Scan Interval (`int`)**: Defines polling frequency in minutes (minimum 15). Effective only if "Active Polling at Scan Interval" is enabled.
-- **Debug Logs (`bool`)**: Turns on DEBUG level logging. Helpful for development or troubleshooting. This change is effective immediately without  the need for a restart.
+- **Debug Logs (`bool`)**: Turns on DEBUG level logging. Helpful for development or troubleshooting. This change is effective immediately without the need for a restart.
 
 _Note: A Home Assistant restart is required for changes to take effect._
 

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ Find configuration options under **Settings ➤ Devices & Services ➤ Integrati
 - **Cloud Update at Startup (`bool`)**: Toggle cloud updates at integration startup. Ideal for development or frequent HA restarts.
 - **Active Polling at Scan Interval (`bool`)**: Enable or disable active polling.
 - **Scan Interval (`int`)**: Defines polling frequency in minutes (minimum 15). Effective only if "Active Polling at Scan Interval" is enabled.
+- **Debug Logs (`bool`)**: Turns on DEBUG level logging. Helpful for development or troubleshooting. This change is effective immediately without  the need for a restart.
 
 _Note: A Home Assistant restart is required for changes to take effect._
 


### PR DESCRIPTION
The debug logs option is nice to have for dev work or helping users get more log info quickly. The `update_listener` will be useful for instantaneous changes for the options we currently have, and new options in a future PR. This will be most useful if users need to try multiple options on the fly without having to reboot each time. i.e. trying different endpoints or data format levels.

# Debug Logs Option
### Add Debug Option to Configuration Schema
- **Files Affected:** `__init__.py`
- **Changes:**
  - Updated the integration’s configuration schema to include a new optional boolean key `"debug"` with a default value of `False`.
  - This allows users to enable or disable debug logging via YAML or UI options.

### Set Logger Level at Setup
- **Files Affected:** `__init__.py`
- **Changes:**
  - Modified the `async_setup_entry` function to check for the `"debug"` option.
  - When `"debug"` is enabled, the integration’s logger level is set to `DEBUG`; otherwise, it defaults to `INFO`.

### Update Options Flow to Include Debug Setting
- **Files Affected:** `config_flow.py`
- **Changes:**
  - Added the `"debug"` option to the options flow form so that users can toggle debug mode after initial setup.
  - The options form now displays the current debug setting and allows users to update it.

### Add an Update Listener for Dynamic Debug Changes
- **Files Affected:** `__init__.py`
- **Changes:**
  - Registered an update listener using `config_entry.add_update_listener` in `async_setup_entry`.
  - The listener adjusts both the logger’s level and its handlers’ levels immediately based on the new `"debug"` option.
  - This change ensures that toggling debug mode takes effect immediately without requiring a full reload of the integration.

---

# Code Cleanup
- **Changes:**
  - Changed logging from `info` to `debug`. This is the last usages of `info`. As previously discussed `info` **was** reserved for HA Core, but it seems that guidance has changed to "[Do not print out API keys, tokens, usernames or passwords (even if they are wrong). Be restrictive with _LOGGER.info, use _LOGGER.debug for anything which is not targetting the user.](https://developers.home-assistant.io/docs/development_guidelines/?_highlight=log#log-messages)". 
  - A larger effort will have to take place to remove all usernames/emails/VINs to be sure we are compliant. Additionally, we should be strategic about use of `info` logging.