### PR TITLE
fix: Logger.info

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -208,7 +208,7 @@ class AudiAccount(AudiConnectObserver):
             await self.connection.set_vehicle_window_heating(vin, False)
 
     async def start_climate_control(self, service):
-        _LOGGER.info("Initiating Start Climate Control Service...")
+        _LOGGER.debug("Initiating Start Climate Control Service...")
         vin = service.data.get(CONF_VIN).lower()
         # Optional Parameters
         temp_f = service.data.get(CONF_CLIMATE_TEMP_F, None)

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -174,14 +174,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             "Options flow initiated for audiconnect: %s", self._config_entry.title
         )
         if user_input is not None:
-            _LOGGER.info("Received user input for options: %s", user_input)
+            _LOGGER.debug("Received user input for options: %s", user_input)
             return self.async_create_entry(title="", data=user_input)
 
         current_scan_interval = self._config_entry.options.get(
             CONF_SCAN_INTERVAL,
             self._config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL),
         )
-        _LOGGER.info(
+        _LOGGER.debug(
             "Retrieved current scan interval for audiconnect %s: %s minutes",
             self._config_entry.title,
             current_scan_interval,

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -50,7 +50,7 @@ class Instrument:
         self._vehicle = vehicle
 
         if not mutable and self.is_mutable:
-            _LOGGER.info("Skipping %s because mutable", self)
+            _LOGGER.debug("Skipping %s because mutable", self)
             return False
 
         if not self.is_supported:


### PR DESCRIPTION
## Minor Code Cleanup
- Last of the `_LOGGER.info` changed to `_LOGGER.debug` until we can do a full code cleanup according to [guidelines](https://developers.home-assistant.io/docs/development_guidelines/#log-messages):