### PR TITLE
fix: Lock/Unlock Service (US)

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -482,20 +482,14 @@ class AudiService:
         )
         res = await self._api.request(
             "POST",
-            "{homeRegion}/fs-car/bs/rlu/v1/{type}/{country}/vehicles/{vin}/actions".format(
-                homeRegion=await self._get_home_region(vin.upper()),
-                type=self._type,
-                country=self._country,
+            "https://mal-3a.prd.eu.dp.vwg-connect.com/api/bs/rlu/v1/vehicles/{vin}/lock".format(
                 vin=vin.upper(),
             ),
             headers=headers,
             data=data,
         )
 
-        checkUrl = "{homeRegion}/fs-car/bs/rlu/v1/{type}/{country}/vehicles/{vin}/requests/{requestId}/status".format(
-            homeRegion=await self._get_home_region(vin.upper()),
-            type=self._type,
-            country=self._country,
+        checkUrl = "https://mal-3a.prd.eu.dp.vwg-connect.com/api/bs/rlu/v1/vehicles/{vin}/requests/{requestId}/status".format(
             vin=vin.upper(),
             requestId=res["rluActionResponse"]["requestId"],
         )


### PR DESCRIPTION
Fixes the `execute_vehicle_action` > `Lock`/`Unlock`.

_This fix is currently only available in the US. 
We will extend the fix to the EU once we receive input from a user in that region who has remote door lock capabilities and can capture the request_