### PR TITLE
fix: `execute_vehicle_action` > `stop_climatisation` 

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -561,8 +561,8 @@ class AudiService:
     async def set_climatisation(self, vin: str, start: bool):
         api_level = self._api_level
         if start:
-            _LOGGER.warning(
-                "The 'Start Climatisation (Legacy)' service is deprecated and will be removed in a future release. "
+            raise NotImplementedError(
+                "The 'Start Climatisation (Legacy)' service is deprecated and no longer functional. "
                 "Please use the 'Start Climate Control' service instead."
             )
             # data = '{"action":{"type": "startClimatisation","settings": {"targetTemperature": 2940,"climatisationWithoutHVpower": true,"heaterSource": "electric","climaterElementSettings": {"isClimatisationAtUnlock": false, "isMirrorHeatingEnabled": true,}}}}'

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -566,7 +566,7 @@ class AudiService:
                 "Please use the 'Start Climate Control' service instead."
             )
             # data = '{"action":{"type": "startClimatisation","settings": {"targetTemperature": 2940,"climatisationWithoutHVpower": true,"heaterSource": "electric","climaterElementSettings": {"isClimatisationAtUnlock": false, "isMirrorHeatingEnabled": true,}}}}'
-            return
+
         else:
             if api_level == 0:
                 data = '{"action":{"type": "stopClimatisation"}}'


### PR DESCRIPTION
- Fixes the `Execute Vehicle Action` > `Stop Climatisation` service.
- Deprecated the `execute_vehicle_action` > `Start Climatisation (Legacy)` service. Raise exception added to point users to use the `Start Climate Control` service call instead.

### Notes:
- Check Request Succeeded is not yet implemented for API Level 1. Fix coming soon.