### PR TITLE
fix: `Is moving` sensor should be `MOVING` device class

### DIFF
--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -782,7 +782,7 @@ def create_instruments():
             attr="is_moving",
             name="Is moving",
             icon="mdi:motion-outline",
-            device_class=BinarySensorDeviceClass.MOTION,
+            device_class=BinarySensorDeviceClass.MOVING,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
     ]


### PR DESCRIPTION
Device Class of `MOTION` gives values of `Detected` or `Clear`. 
Device Class of `MOVING` gives values of `Moving` or `Not moving`.

For the `Is moving` binary sensor, `MOVING` is a better fit.
