### PR TITLE
fix: Fix Execute Vehicle Action > `Start Charger` & `Start timed Charger`

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -541,7 +541,7 @@ class AudiService:
             "application/json", None, "emea.bff.cariad.digital"
         )
         await self._api.request(
-            "POST",
+            "PUT",
             "https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/charging/mode".format(
                 vin=vin.upper(),
             ),

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -540,7 +540,7 @@ class AudiService:
         headers = self._get_vehicle_action_header(
             "application/json", None, "emea.bff.cariad.digital"
         )
-        res = await self._api.request(
+        await self._api.request(
             "POST",
             "https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/charging/mode".format(
                 vin=vin.upper(),

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -523,40 +523,45 @@ class AudiService:
 
     async def set_battery_charger(self, vin: str, start: bool, timer: bool):
         if start and timer:
-            data = '{ "action": { "type": "selectChargingMode", "settings": { "chargeModeSelection": { "value": "timerBasedCharging" } } }}'
+            raise NotImplementedError(
+                "The 'Start Timed Charger' service is not currently implemented."
+            )
+            # data = '{ "action": { "type": "selectChargingMode", "settings": { "chargeModeSelection": { "value": "timerBasedCharging" } } }}'
         elif start:
-            data = '{ "action": { "type": "start" }}'
+            # data = '{ "action": { "type": "start" }}'
+            data = { "preferredChargeMode": "manual" }
+            data = json.dumps(data)
         else:
-            data = '{ "action": { "type": "stop" }}'
+            raise NotImplementedError(
+                "The 'Stop Charger' service is not currently implemented."
+            )
+            # data = '{ "action": { "type": "stop" }}'
 
-        headers = self._get_vehicle_action_header("application/json", None)
+        headers = self._get_vehicle_action_header("application/json", None, "emea.bff.cariad.digital")
         res = await self._api.request(
             "POST",
-            "{homeRegion}/fs-car/bs/batterycharge/v1/{type}/{country}/vehicles/{vin}/charger/actions".format(
-                homeRegion=await self._get_home_region(vin.upper()),
-                type=self._type,
-                country=self._country,
+            "https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/charging/mode".format(
                 vin=vin.upper(),
             ),
             headers=headers,
             data=data,
         )
 
-        checkUrl = "{homeRegion}/fs-car/bs/batterycharge/v1/{type}/{country}/vehicles/{vin}/charger/actions/{actionid}".format(
-            homeRegion=await self._get_home_region(vin.upper()),
-            type=self._type,
-            country=self._country,
-            vin=vin.upper(),
-            actionid=res["action"]["actionId"],
-        )
+        # checkUrl = "{homeRegion}/fs-car/bs/batterycharge/v1/{type}/{country}/vehicles/{vin}/charger/actions/{actionid}".format(
+        #     homeRegion=await self._get_home_region(vin.upper()),
+        #     type=self._type,
+        #     country=self._country,
+        #     vin=vin.upper(),
+        #     actionid=res["action"]["actionId"],
+        # )
 
-        await self.check_request_succeeded(
-            checkUrl,
-            "start charger" if start else "stop charger",
-            SUCCEEDED,
-            FAILED,
-            "action.actionState",
-        )
+        # await self.check_request_succeeded(
+        #     checkUrl,
+        #     "start charger" if start else "stop charger",
+        #     SUCCEEDED,
+        #     FAILED,
+        #     "action.actionState",
+        # )
 
     async def set_climatisation(self, vin: str, start: bool):
         api_level = self._api_level

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -523,23 +523,19 @@ class AudiService:
 
     async def set_battery_charger(self, vin: str, start: bool, timer: bool):
         if start and timer:
-            raise NotImplementedError(
-                "The 'Start Timed Charger' service is not currently implemented."
-            )
-            # data = '{ "action": { "type": "selectChargingMode", "settings": { "chargeModeSelection": { "value": "timerBasedCharging" } } }}'
+            data = {"preferredChargeMode": "timer"}
         elif start:
-            # data = '{ "action": { "type": "start" }}'
             data = {"preferredChargeMode": "manual"}
-            data = json.dumps(data)
         else:
             raise NotImplementedError(
-                "The 'Stop Charger' service is not currently implemented."
+                "The 'Stop Charger' service is deprecated and no longer functional."
             )
-            # data = '{ "action": { "type": "stop" }}'
 
-        headers = self._get_vehicle_action_header(
-            "application/json", None, "emea.bff.cariad.digital"
-        )
+        data = json.dumps(data)
+        headers = {
+            "Authorization": "Bearer " + self._bearer_token_json["access_token"]
+        }
+
         await self._api.request(
             "PUT",
             "https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/charging/mode".format(

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -528,7 +528,7 @@ class AudiService:
             data = {"preferredChargeMode": "manual"}
         else:
             raise NotImplementedError(
-                "The 'Stop Charger' service is deprecated and no longer functional."
+                "The 'Stop Charger' service is deprecated and will be removed in a future release."
             )
 
         data = json.dumps(data)

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -532,9 +532,7 @@ class AudiService:
             )
 
         data = json.dumps(data)
-        headers = {
-            "Authorization": "Bearer " + self._bearer_token_json["access_token"]
-        }
+        headers = {"Authorization": "Bearer " + self._bearer_token_json["access_token"]}
 
         await self._api.request(
             "PUT",

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -529,7 +529,7 @@ class AudiService:
             # data = '{ "action": { "type": "selectChargingMode", "settings": { "chargeModeSelection": { "value": "timerBasedCharging" } } }}'
         elif start:
             # data = '{ "action": { "type": "start" }}'
-            data = { "preferredChargeMode": "manual" }
+            data = {"preferredChargeMode": "manual"}
             data = json.dumps(data)
         else:
             raise NotImplementedError(
@@ -537,7 +537,9 @@ class AudiService:
             )
             # data = '{ "action": { "type": "stop" }}'
 
-        headers = self._get_vehicle_action_header("application/json", None, "emea.bff.cariad.digital")
+        headers = self._get_vehicle_action_header(
+            "application/json", None, "emea.bff.cariad.digital"
+        )
         res = await self._api.request(
             "POST",
             "https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/charging/mode".format(


### PR DESCRIPTION
Fixes `Execute Vehicle Action` > `Start Charger` & `Start timed Charger` only.

### Notes
- Currently there is no check to see if the request succeeded before running the refresh cloud data service. This is on the list of fixes to come.
    - You can workaround this by adding a delay (~10-30s) in your automation/script and then running a `refresh cloud data` action.
- Setting the charger schedule is a separate action which we will work on for a future release.
- `Stop Charger` is deprecated and will be removed in a future release.

Thanks to @thomas-hass for leading the "charge" and finding a fix for this.