### PR TITLE
feat: Adding exception when attempting actions where sPin is required and none is provided

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -1381,6 +1381,9 @@ class AudiService:
         self.vwToken = json.loads(mbboauth_refresh_rsptxt)
 
     def _generate_security_pin_hash(self, challenge):
+        if self._spin is None:
+            raise Exception("sPin is required to perform this action")
+
         pin = to_byte_array(self._spin)
         byteChallenge = to_byte_array(challenge)
         b = bytes(pin + byteChallenge)


### PR DESCRIPTION
When I was attempting to get my car to lock with the integration I was getting a `NoneType has no len()` from the plugin.

This change adds a new exception before hashing the pin to make sure the pin has a value, this will allow for better feedback to the user in the logs of home assistant.