### PR TITLE
feat: add set_target_soc service for battery charge level control

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -32,6 +32,7 @@ from .const import (
     DEFAULT_API_LEVEL,
     API_LEVELS,
     CONF_DURATION,
+    CONF_TARGET_SOC,
 )
 from .dashboard import Dashboard
 
@@ -69,6 +70,16 @@ SERVICE_START_AUXILIARY_HEATING_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_VIN): cv.string,
         vol.Optional(CONF_DURATION): cv.positive_int,
+    }
+)
+
+SERVICE_SET_TARGET_SOC = "set_target_soc"
+SERVICE_SET_TARGET_SOC_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_VIN): cv.string,
+        vol.Required(CONF_TARGET_SOC): vol.All(
+            cv.positive_int, vol.Range(min=20, max=100)
+        ),
     }
 )
 
@@ -137,6 +148,12 @@ class AudiAccount(AudiConnectObserver):
             SERVICE_START_AUXILIARY_HEATING,
             self.start_auxiliary_heating,
             schema=SERVICE_START_AUXILIARY_HEATING_SCHEMA,
+        )
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_TARGET_SOC,
+            self.set_target_soc,
+            schema=SERVICE_SET_TARGET_SOC_SCHEMA,
         )
 
         self.connection.add_observer(self)
@@ -276,6 +293,17 @@ class AudiAccount(AudiConnectObserver):
             activate=True,
             duration=duration,
         )
+
+    async def set_target_soc(self, service):
+        """Set the target state of charge for the vehicle battery."""
+        vin = service.data.get(CONF_VIN).lower()
+        target_soc = service.data.get(CONF_TARGET_SOC)
+
+        _LOGGER.debug(
+            f"Initiating 'Set Target SOC' action to {target_soc}% for VIN {vin}..."
+        )
+
+        await self.connection.set_target_state_of_charge(vin, target_soc)
 
     async def handle_notification(self, vin: str, action: str) -> None:
         await self._refresh_vehicle_data(vin)

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -265,6 +265,38 @@ class AudiConnectAccount:
                 ),
             )
 
+    async def set_target_state_of_charge(self, vin: str, target_soc: int):
+        """Set the target state of charge for the vehicle battery."""
+        if not self._loggedin:
+            await self.login()
+
+        if not self._loggedin:
+            return False
+
+        try:
+            _LOGGER.debug(
+                "Setting target state of charge to %d%% for vehicle %s",
+                target_soc,
+                vin,
+            )
+
+            await self._audi_service.set_target_state_of_charge(vin, target_soc)
+
+            _LOGGER.debug(
+                "Successfully set target state of charge to %d%% for vehicle %s",
+                target_soc,
+                vin,
+            )
+
+            return True
+
+        except Exception as exception:
+            log_exception(
+                exception,
+                "Unable to set target state of charge for vehicle {}".format(vin),
+            )
+            return False
+
     async def set_vehicle_climatisation(self, vin: str, activate: bool):
         if not self._loggedin:
             await self.login()

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -559,6 +559,27 @@ class AudiService:
         #     "action.actionState",
         # )
 
+    async def set_target_state_of_charge(self, vin: str, target_soc: int):
+        """Set the target state of charge (battery percentage)."""
+        if not (20 <= target_soc <= 100):
+            raise ValueError(
+                "Target state of charge must be between 20 and 100 percent"
+            )
+
+        # Use Cariad BFF API (requires API level 1)
+        headers = {"Authorization": "Bearer " + self._bearer_token_json["access_token"]}
+
+        data = {"targetSOC_pct": target_soc}
+
+        await self._api.request(
+            "PUT",
+            "https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/charging/settings".format(
+                vin=vin.upper(),
+            ),
+            headers=headers,
+            data=json.dumps(data),
+        )
+
     async def set_climatisation(self, vin: str, start: bool):
         api_level = self._api_level
         country = self._country

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -14,6 +14,7 @@ CONF_SCAN_INITIAL = "scan_initial"
 CONF_SCAN_ACTIVE = "scan_active"
 CONF_API_LEVEL = "api_level"
 CONF_DURATION = "duration"
+CONF_TARGET_SOC = "target_soc"
 
 MIN_UPDATE_INTERVAL = 15
 DEFAULT_UPDATE_INTERVAL = 15

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -1,3 +1,4 @@
+---
 # Describes the format for available services for audiconnect
 
 refresh_vehicle_data:
@@ -81,3 +82,20 @@ start_auxiliary_heating:
           max: 60
           step: 10
           unit_of_measurement: "minutes"
+
+set_target_soc:
+  fields:
+    vin:
+      required: true
+      example: WBANXXXXXX1234567
+      selector:
+        text:
+    target_soc:
+      required: true
+      example: 80
+      selector:
+        number:
+          min: 20
+          max: 100
+          step: 5
+          unit_of_measurement: "%"

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -145,6 +145,20 @@
           "description": "The number of minutes the auxiliary heater should run before turning off. Default is 20 minutes if not provided."
         }
       }
+    },
+    "set_target_soc": {
+      "name": "Set Target State of Charge",
+      "description": "Set the target state of charge (battery %) for the vehicle.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "The Vehicle Identification Number (VIN) of the Audi vehicle. This should be a 17-character identifier unique to each vehicle."
+        },
+        "target_soc": {
+          "name": "Target State of Charge",
+          "description": "Target state of charge percentage (20-100%)."
+        }
+      }
     }
   }
 }

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -145,6 +145,20 @@
           "description": "The number of minutes the auxiliary heater should run before turning off. Default is 20 minutes if not provided."
         }
       }
+    },
+    "set_target_soc": {
+      "name": "Set Target State of Charge",
+      "description": "Set the target state of charge (battery %) for the vehicle.",
+      "fields": {
+        "vin": {
+          "name": "VIN",
+          "description": "The Vehicle Identification Number (VIN) of the Audi vehicle. This should be a 17-character identifier unique to each vehicle."
+        },
+        "target_soc": {
+          "name": "Target State of Charge",
+          "description": "Target state of charge percentage (20-100%)."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Add new Home Assistant service `audiconnect.set_target_soc` that allows users to set the target state of charge (battery percentage) for their Audi electric/hybrid vehicles.

## Changes
- Add `set_target_state_of_charge()` method in `AudiService` class
- Add corresponding method in `AudiConnectAccount` for error handling
- Register new service in `AudiAccount` with proper schema validation
- Add service configuration in `services.yaml` with UI controls
- Add `CONF_TARGET_SOC` constant for service parameter

## Implementation Details
- Uses Cariad BFF API endpoint `/charging/settings` (API level 1)
- Validates target range 20-100% with proper error handling
- Follows existing service patterns and coding standards
- Includes comprehensive logging and exception handling

## Service Usage
```yaml
service: audiconnect.set_target_soc
data:
  vin: "WBANXXXXXX1234567"
  target_soc: 80
```

Resolves community requests for battery charge target control.