### PR TITLE
fix: Set suggested display precision to 0 for distance items

### DIFF
--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -146,6 +146,7 @@ class Sensor(Instrument):
         device_class=None,
         entity_category=None,
         extra_state_attributes=None,
+        suggested_display_precision=None
     ):
         super().__init__(component="sensor", attr=attr, name=name, icon=icon)
         self.device_class = device_class
@@ -153,6 +154,7 @@ class Sensor(Instrument):
         self.state_class = state_class
         self.entity_category = entity_category
         self.extra_state_attributes = extra_state_attributes
+        self.suggested_display_precision = suggested_display_precision
         self._convert = False
 
     @property
@@ -803,3 +805,4 @@ class Dashboard:
             for instrument in create_instruments()
             if instrument.setup(connection, vehicle, **config)
         ]
+

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -146,7 +146,7 @@ class Sensor(Instrument):
         device_class=None,
         entity_category=None,
         extra_state_attributes=None,
-        suggested_display_precision=None
+        suggested_display_precision=None,
     ):
         super().__init__(component="sensor", attr=attr, name=name, icon=icon)
         self.device_class = device_class
@@ -805,4 +805,3 @@ class Dashboard:
             for instrument in create_instruments()
             if instrument.setup(connection, vehicle, **config)
         ]
-

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -23,13 +23,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Instrument:
-    def __init__(self, component, attr, name, icon=None):
+    def __init__(
+        self, component, attr, name, icon=None, suggested_display_precision=None
+    ):
         self._attr = attr
         self._component = component
         self._name = name
         self._connection = None
         self._vehicle = None
         self._icon = icon
+        self._suggested_display_precision = suggested_display_precision
 
     def __repr__(self):
         return self.full_name
@@ -78,6 +81,10 @@ class Instrument:
     @property
     def attr(self):
         return self._attr
+
+    @property
+    def suggested_display_precision(self):
+        return self._suggested_display_precision
 
     @property
     def vehicle_name(self):
@@ -148,13 +155,18 @@ class Sensor(Instrument):
         extra_state_attributes=None,
         suggested_display_precision=None,
     ):
-        super().__init__(component="sensor", attr=attr, name=name, icon=icon)
+        super().__init__(
+            component="sensor",
+            attr=attr,
+            name=name,
+            icon=icon,
+            suggested_display_precision=suggested_display_precision,
+        )
         self.device_class = device_class
         self._unit = unit
         self.state_class = state_class
         self.entity_category = entity_category
         self.extra_state_attributes = extra_state_attributes
-        self.suggested_display_precision = suggested_display_precision
         self._convert = False
 
     @property

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -437,6 +437,7 @@ def create_instruments():
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.DISTANCE,
             entity_category=EntityCategory.DIAGNOSTIC,
+            suggested_display_precision=0,
         ),
         Sensor(
             attr="service_adblue_distance",
@@ -444,6 +445,7 @@ def create_instruments():
             icon="mdi:map-marker-distance",
             unit=UnitOfLength.KILOMETERS,
             device_class=SensorDeviceClass.DISTANCE,
+            suggested_display_precision=0,
         ),
         Sensor(
             attr="range",
@@ -451,6 +453,7 @@ def create_instruments():
             icon="mdi:map-marker-distance",
             unit=UnitOfLength.KILOMETERS,
             device_class=SensorDeviceClass.DISTANCE,
+            suggested_display_precision=0,
         ),
         Sensor(
             attr="hybrid_range",
@@ -458,6 +461,7 @@ def create_instruments():
             icon="mdi:map-marker-distance",
             unit=UnitOfLength.KILOMETERS,
             device_class=SensorDeviceClass.DISTANCE,
+            suggested_display_precision=0,
         ),
         Sensor(
             attr="service_inspection_time",
@@ -473,6 +477,7 @@ def create_instruments():
             unit=UnitOfLength.KILOMETERS,
             device_class=SensorDeviceClass.DISTANCE,
             entity_category=EntityCategory.DIAGNOSTIC,
+            suggested_display_precision=0,
         ),
         Sensor(
             attr="oil_change_time",
@@ -488,6 +493,7 @@ def create_instruments():
             unit=UnitOfLength.KILOMETERS,
             device_class=SensorDeviceClass.DISTANCE,
             entity_category=EntityCategory.DIAGNOSTIC,
+            suggested_display_precision=0,
         ),
         Sensor(
             attr="oil_level",
@@ -533,6 +539,7 @@ def create_instruments():
             icon="mdi:map-marker-distance",
             unit=UnitOfLength.KILOMETERS,
             device_class=SensorDeviceClass.DISTANCE,
+            suggested_display_precision=0,
         ),
         Sensor(
             attr="secondary_engine_range",
@@ -540,6 +547,7 @@ def create_instruments():
             icon="mdi:map-marker-distance",
             unit=UnitOfLength.KILOMETERS,
             device_class=SensorDeviceClass.DISTANCE,
+            suggested_display_precision=0,
         ),
         Sensor(
             attr="primary_engine_range_percent",
@@ -795,3 +803,4 @@ class Dashboard:
             for instrument in create_instruments()
             if instrument.setup(connection, vehicle, **config)
         ]
+

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -803,4 +803,3 @@ class Dashboard:
             for instrument in create_instruments()
             if instrument.setup(connection, vehicle, **config)
         ]
-

--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -60,3 +60,9 @@ class AudiSensor(AudiEntity, SensorEntity):
     def extra_state_attributes(self):
         """Return additional state attributes."""
         return self._instrument.extra_state_attributes
+
+    @cached_property
+    def suggested_display_precision(self):
+        """Return the suggested number of decimal digits for display."""
+        return self._instrument.suggested_display_precision
+

--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -61,7 +61,7 @@ class AudiSensor(AudiEntity, SensorEntity):
         """Return additional state attributes."""
         return self._instrument.extra_state_attributes
 
-    @cached_property
+    @property
     def suggested_display_precision(self):
         """Return the suggested number of decimal digits for display."""
         return self._instrument.suggested_display_precision

--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -65,4 +65,3 @@ class AudiSensor(AudiEntity, SensorEntity):
     def suggested_display_precision(self):
         """Return the suggested number of decimal digits for display."""
         return self._instrument.suggested_display_precision
-


### PR DESCRIPTION
This makes distance items like mileage show as rounded number instead of two decimals (which are always `.00` and useless)