### PR TITLE
feat: improve charging mode sensors and add charging type sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.idea

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1981,4 +1981,3 @@ class AudiConnectVehicle:
     def is_moving_supported(self):
         """Return true if vehicle can move."""
         return True
-

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1588,7 +1588,7 @@ class AudiConnectVehicle:
     @property
     def charging_type_supported(self):
         check = self._vehicle.state.get("chargeType")
-        if check:
+        if check and check != "unsupported":
             return True
 
     @property
@@ -1981,3 +1981,4 @@ class AudiConnectVehicle:
     def is_moving_supported(self):
         """Return true if vehicle can move."""
         return True
+

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1558,11 +1558,11 @@ class AudiConnectVehicle:
     def charging_mode(self):
         """Return charging mode"""
         if self.charging_mode_supported:
-            return self._vehicle.state.get("chargingMode")
+            return self._vehicle.state.get("chargeMode")
 
     @property
     def charging_mode_supported(self):
-        check = self._vehicle.state.get("chargingMode")
+        check = self._vehicle.state.get("chargeMode")
         return check is not None and check != "unsupported"
 
     @property
@@ -1575,6 +1575,18 @@ class AudiConnectVehicle:
     def energy_flow_supported(self):
         check = self._vehicle.state.get("energyFlow")
         if check is not None:
+            return True
+
+    @property
+    def charging_type(self):
+        """Return charging type"""
+        if self.charging_type_supported:
+            return self._vehicle.state.get("chargeType")
+
+    @property
+    def charging_type_supported(self):
+        check = self._vehicle.state.get("chargeType")
+        if check:
             return True
 
     @property

--- a/custom_components/audiconnect/audi_models.py
+++ b/custom_components/audiconnect/audi_models.py
@@ -211,7 +211,7 @@ class VehicleDataResponse:
         )
         self._tryAppendStateWithTs(
             data,
-            "chargingMode",
+            "chargeType",
             -1,
             ["charging", "chargingStatus", "value", "chargeType"],
         )

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -47,6 +47,7 @@ RESOURCES = [
     "oil_level",
     "charging_state",
     "charging_mode",
+    "charging_type",
     "energy_flow",
     "max_charge_current",
     "engine_type1",

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -525,6 +525,10 @@ def create_instruments():
             name="Charging mode",
         ),
         Sensor(
+            attr="charging_type",
+            name="Charging type",
+        ),
+        Sensor(
             attr="energy_flow",
             name="Energy flow",
         ),


### PR DESCRIPTION
## Summary

This PR addresses issue #587 by fixing the existing `charging_mode` sensor and adding a new `charging_type` sensor for better charging configuration visibility.

### Problem
- Issue #587 requested ability to detect and change charging modes
- Investigation revealed `charging_mode` sensor was reading wrong API field, showing "invalid" instead of actual charging mode
- Additional charging type data from API was unused

### Solution
- Fixed `charging_mode` to read correct API field (`chargeMode`)
- Added new `charging_type` sensor to surface the `chargeType` API field
- Updated field mappings to match API names exactly

## Changes Made

**Field Mappings (`audi_models.py`)**
- Updated mapping to use API-consistent field names
- `chargeMode` API field → `chargeMode` internal field
- `chargeType` API field → `chargeType` internal field

**Properties (`audi_connect_account.py`)**
- Fixed `charging_mode` property to read from correct field
- Added `charging_type` property following existing patterns

**Dashboard & Resources**
- Added `charging_type` sensor configuration
- Registered new sensor in resources

## Results

**Before:**
- `charging_mode` = "invalid" (broken)
- No charging type information

**After:**
- `charging_mode` = "manual"/"timer" (working)
- `charging_type` = charging energy source info (observed values: "invalid", "ac" - presumably AC/DC charging type)

## Testing
- Verified with live vehicle API data showing `chargeMode: "manual"` and `chargeType: "invalid"`
- Separately observed `chargeType: "ac"` suggesting this indicates charging energy source (AC/DC)
- All pre-commit checks pass
- No breaking changes - existing automations continue working with correct data

Fixes #587