### PR TITLE
fix: add missing climatisation_at_unlock parameter to start_climate_control method

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -341,6 +341,7 @@ class AudiConnectAccount:
         seat_fr: bool,
         seat_rl: bool,
         seat_rr: bool,
+        climatisation_at_unlock: bool,
     ):
         if not self._loggedin:
             await self.login()
@@ -350,7 +351,7 @@ class AudiConnectAccount:
 
         try:
             _LOGGER.debug(
-                f"Sending command to start climate control for vehicle {vin} with settings - Temp(F): {temp_f}, Temp(C): {temp_c}, Glass Heating: {glass_heating}, Seat FL: {seat_fl}, Seat FR: {seat_fr}, Seat RL: {seat_rl}, Seat RR: {seat_rr}"
+                f"Sending command to start climate control for vehicle {vin} with settings - Temp(F): {temp_f}, Temp(C): {temp_c}, Glass Heating: {glass_heating}, Seat FL: {seat_fl}, Seat FR: {seat_fr}, Seat RL: {seat_rl}, Seat RR: {seat_rr}, Climatisation at Unlock: {climatisation_at_unlock}"
             )
 
             await self._audi_service.start_climate_control(
@@ -362,6 +363,7 @@ class AudiConnectAccount:
                 seat_fr,
                 seat_rl,
                 seat_rr,
+                climatisation_at_unlock,
             )
 
             _LOGGER.debug(f"Successfully started climate control of vehicle {vin}")


### PR DESCRIPTION
## Summary
- Fixes TypeError when calling start_climate_control service with climatisation_at_unlock parameter
- Updates method signature to accept the missing parameter that was added in #611
- Updates debug logging to include the new parameter

## Problem
Issue #613 reported that the `start_climate_control` service was failing with:
```
TypeError: AudiConnectAccount.start_climate_control() takes 9 positional arguments but 10 were given
```

This happened because the climatisation_at_unlock parameter was added to the Home Assistant service interface in commit 7de7cfe but the underlying `AudiConnectAccount.start_climate_control` method signature was not updated.

## Solution
Updated `audi_connect_account.py` to:
- Add `climatisation_at_unlock: bool` parameter to method signature
- Include the parameter in debug logging
- Pass the parameter through to `_audi_service.start_climate_control`

## Test plan
- [x] Method signature accepts correct number of parameters
- [x] Pre-commit hooks pass
- [x] Tested with Home Assistant - start_climate_control service now works without errors
- [x] Verified climatisation_at_unlock parameter is properly handled

Closes #613