### PR TITLE
fix: use static api endpoint for non US region on api_level 1 (aka fix lock in DE country)

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -362,6 +362,13 @@ class AudiService:
         return TripDataResponse(td_current), TripDataResponse(td_reset_trip)
 
     async def _fill_home_region(self, vin: str):
+        # the home-region endpoint returns
+        # https://ha-5a.prd.eu.vwg.vwautocloud.net which is no valid endpoint
+        # (at least not in DE region). set it statically.
+        if self._country.upper() != "US" and self._api_level == 1:
+            self._homeRegion[vin] = "https://mal-3a.prd.eu.dp.vwg-connect.com"
+            self._homeRegionSetter[vin] = "https://mal-3a.prd.eu.dp.vwg-connect.com"
+            return
         self._homeRegion[vin] = "https://msg.volkswagen.de"
         self._homeRegionSetter[vin] = "https://mal-1a.prd.ece.vwg-connect.com"
 


### PR DESCRIPTION
see discussion in https://github.com/audiconnect/audi_connect_ha/issues/645#issuecomment-3367961399
`_fill_home_region `doesn't determine the correct region if outside US. Tested with Q6 in switzerland (country = DE). This fixes the retrival the security-token in `_get_security_token` thus fixing locking/unlocking the car. Note that the status is only updated after the polling interval due to another problem.