### PR TITLE
fix: #659 by using existing region formatting logic consistently

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -546,7 +546,6 @@ class AudiService:
             "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/charging/mode".format(
                 vin=vin.upper(),
                 region="emea" if self._country.upper() != "US" else "na",
-
             ),
             headers=headers,
             data=data,
@@ -585,7 +584,6 @@ class AudiService:
             "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/charging/settings".format(
                 vin=vin.upper(),
                 region="emea" if self._country.upper() != "US" else "na",
-
             ),
             headers=headers,
             data=json.dumps(data),
@@ -662,7 +660,6 @@ class AudiService:
                     "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/climatisation/stop".format(
                         vin=vin.upper(),
                         region="emea" if self._country.upper() != "US" else "na",
-
                     ),
                     headers=headers,
                     data=data,
@@ -815,7 +812,6 @@ class AudiService:
                 "https://{region}.bff.cariad.digital/vehicle/v1/vehicles/{vin}/climatisation/start".format(
                     vin=vin.upper(),
                     region="emea" if self._country.upper() != "US" else "na",
-
                 ),
                 headers=headers,
                 data=data,


### PR DESCRIPTION
Roughly half of the calls to the region specified URLs in this file were using the region formatting code. The other half were just hard-coded to "emea". I replaced all the hard-coded occurrences with the existing logic to make them all consistent. 

Probably even better is to define the region in the initializer but I'm neither good at Python nor do I know any of the design considerations that led to it being like this. I just want automation to once again warm up my car on cold school days.

I replaced this file on my HA instance with my version and I can once again control the climate system from HA.

This addresses #659.