### PR TITLE
fix: #659: consistent region for `*.bff.cariad.digital` URLs

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -195,10 +195,11 @@ class AudiService:
         }
         self._api.use_token(self._bearer_token_json)
         data = await self._api.get(
-            self.__get_cariad_url_for_vin(vin, "selectivestatus?jobs={jobs}",
-                jobs=",".join(JOBS2QUERY))
+            self.__get_cariad_url_for_vin(
+                vin, "selectivestatus?jobs={jobs}", jobs=",".join(JOBS2QUERY)
+            )
         )
-        
+
         _LOGGER.debug("Vehicle data returned for VIN: %s: %s", redacted_vin, data)
         return VehicleDataResponse(data)
 
@@ -487,23 +488,25 @@ class AudiService:
 
         return headers
 
-    def __build_url(self, base_url: str, path_and_query: str, **path_and_query_kwargs: dict):
+    def __build_url(
+        self, base_url: str, path_and_query: str, **path_and_query_kwargs: dict
+    ):
         action_path = path_and_query.format(**path_and_query_kwargs)
 
-        return base_url.rstrip('/') + '/' + action_path.lstrip('/')
+        return base_url.rstrip("/") + "/" + action_path.lstrip("/")
 
     def __get_cariad_url(self, path_and_query: str, **path_and_query_kwargs: dict):
         base_url = "https://{region}.bff.cariad.digital".format(
             region="emea" if self._country.upper() != "US" else "na"
         )
-        
+
         return self.__build_url(base_url, path_and_query, **path_and_query_kwargs)
 
-    def __get_cariad_url_for_vin(self, vin: str, path_and_query: str, **path_and_query_kwargs: dict):
-        base_url = self.__get_cariad_url("/vehicle/v1/vehicles/{vin}",
-            vin=vin.upper()
-        )
-        
+    def __get_cariad_url_for_vin(
+        self, vin: str, path_and_query: str, **path_and_query_kwargs: dict
+    ):
+        base_url = self.__get_cariad_url("/vehicle/v1/vehicles/{vin}", vin=vin.upper())
+
         return self.__build_url(base_url, path_and_query, **path_and_query_kwargs)
 
     async def set_vehicle_lock(self, vin: str, lock: bool):
@@ -894,8 +897,8 @@ class AudiService:
         }
         await self._api.request(
             "POST",
-            self.__get_cariad_url_for_vin(vin, "auxilaryheating/{action}",
-                action="start" if activate else "stop"
+            self.__get_cariad_url_for_vin(
+                vin, "auxilaryheating/{action}", action="start" if activate else "stop"
             ),
             headers=headers,
             data=data,
@@ -1121,7 +1124,7 @@ class AudiService:
             self._client_id = marketcfg_json["idkClientIDAndroidLive"]
 
         self._authorizationServerBaseURLLive = self.__get_cariad_url("/login/v1/audi")
-        
+
         if "authorizationServerBaseURLLive" in marketcfg_json:
             self._authorizationServerBaseURLLive = marketcfg_json[
                 "myAudiAuthorizationServerProxyServiceURLProduction"


### PR DESCRIPTION
Related to #669--credit there for identifying the problem and solution.

Essentially, there are a series of calls to `*.bff.cariad.digital` URLs, and while the region should be populated using logic based on `self._country`, many presently hardcode `emea`. The correct region-mapping logic was already present in several calls, just now it's used for all.

This PR just pulls all that URL-building out to two shared functions, `self.__get_cariad_url` and `self.__get_cariad_url_for_vin`, which use the correct hostname and conveniently concatenate things together.

I pulled this PR together to a couple of issues in the existing PR, as noted in comments by @cdnninja. The solution is fundamentally the same, but there were some copy-paste errors and repetition that I saw an opportunity to avoid.