### PR TITLE
fix: Fix pre-heater endpoint

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -899,7 +899,7 @@ class AudiService:
         res = await self._api.request(
             "POST",
             self.__get_cariad_url_for_vin(
-                vin, "auxilaryheating/{action}", action="start" if activate else "stop"
+                vin, "auxiliaryheating/{action}", action="start" if activate else "stop"
             ),
             headers=headers,
             data=data,


### PR DESCRIPTION
This pull request contains a small fix to a URL path typo in the `set_pre_heater` method. The change corrects the spelling of "auxilaryheating" to "auxiliaryheating" in the API endpoint, ensuring requests are made to the correct URL. The regression was introduced in #676.