### PR TITLE
fix: Use f-string for error message in audi_services.py

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -286,7 +286,7 @@ class AudiService:
         )
         vins = json.loads(rep_rsptxt)
         if "errors" in vins:
-            raise Exception("API returned errors: {vins['errors']}")
+            raise Exception(f"API returned errors: {vins['errors']}")
 
         if "data" not in vins or vins["data"] is None:
             raise Exception("No data in API response")


### PR DESCRIPTION
@Kolbi 
Missed this while reviewing #693 . I believe we need f string so we can print the errors in the logs.