### PR TITLE
fix: Update authentication flow to use Cariad OIDC endpoints

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -1160,7 +1160,7 @@ class AudiService:
         marketcfg_url = "https://content.app.my.audi.com/service/mobileapp/configurations/market/{c}/{l}?v=4.23.1".format(
             c=self._country, l=self._language
         )
-        openidcfg_url = self.__get_cariad_url("/login/v1/idk/openid-configuration")
+        openidcfg_url = self.__get_cariad_url("/auth/v1/idk/oidc/openid-configuration")
 
         # get market config
         marketcfg_json = await self._api.request("GET", marketcfg_url, None)
@@ -1188,7 +1188,7 @@ class AudiService:
         if "authorization_endpoint" in openidcfg_json:
             authorization_endpoint = openidcfg_json["authorization_endpoint"]
 
-        self._tokenEndpoint = self.__get_cariad_url("/login/v1/idk/token")
+        self._tokenEndpoint = self.__get_cariad_url("/auth/v1/idk/oidc/token")
 
         if "token_endpoint" in openidcfg_json:
             self._tokenEndpoint = openidcfg_json["token_endpoint"]


### PR DESCRIPTION
This PR fixes the login issues (specifically invalid_client errors) caused by recent changes in the VAG/Audi authentication backend.

The VAG Group has migrated their identity services to the new Cariad infrastructure. The original endpoints used in this integration are no longer supported or have been restricted, resulting in failed authentication attempts.

**Changes made**:
- Updated OpenID Configuration URL: Changed the discovery endpoint to point to the new Cariad OIDC configuration (/auth/v1/idk/oidc/openid-configuration).
- Updated Token Endpoints: Redirected token acquisition and refresh calls to the new Cariad token endpoint (/auth/v1/idk/oidc/token).

**Testing**
- Verified that the integration successfully authenticates and retrieves the access token.
- Verified that logs no longer show invalid_client exceptions.

This fix aligns the integration with recent backend migration patterns observed in ioBroker VW-connect project.