### PR TITLE
fix: handle missing refresh_token in mbboauth auth response (fixes #748)

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -1499,4 +1499,3 @@ class AudiService:
 
 
 __all__ = ["AudiService"]
-

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -1452,33 +1452,41 @@ class AudiService:
         self.mbboauthToken = mbboauth_auth_json
 
         # mbboauth refresh (app immediately refreshes the token)
-        headers = {
-            "Accept": "application/json",
-            "Accept-Charset": "utf-8",
-            "User-Agent": AudiAPI.HDR_USER_AGENT,
-            "Content-Type": "application/x-www-form-urlencoded",
-            "X-Client-ID": self.xclientId,
-        }
-        mbboauth_refresh_data = {
-            "grant_type": "refresh_token",
-            "token": mbboauth_auth_json["refresh_token"],
-            "scope": "sc2:fal",
-            # "vin": vin,  << App uses a dedicated VIN here, but it works without, don't know
-        }
-        encoded_mbboauth_refresh_data = urlencode(
-            mbboauth_refresh_data, encoding="utf-8"
-        ).replace("+", "%20")
-        mbboauth_refresh_rsp, mbboauth_refresh_rsptxt = await self._api.request(
-            "POST",
-            self.mbbOAuthBaseURL + "/mobile/oauth2/v1/token",
-            encoded_mbboauth_refresh_data,
-            headers=headers,
-            allow_redirects=False,
-            cookies=mbboauth_client_reg_rsp.cookies,
-            rsp_wtxt=True,
-        )
-        # this code is the old "vwToken"
-        self.vwToken = json.loads(mbboauth_refresh_rsptxt)
+        # The MBB OAuth auth response no longer always includes a refresh_token.
+        # Skip the immediate refresh if absent and use the auth token directly.
+        if "refresh_token" in mbboauth_auth_json:
+            headers = {
+                "Accept": "application/json",
+                "Accept-Charset": "utf-8",
+                "User-Agent": AudiAPI.HDR_USER_AGENT,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-Client-ID": self.xclientId,
+            }
+            mbboauth_refresh_data = {
+                "grant_type": "refresh_token",
+                "token": mbboauth_auth_json["refresh_token"],
+                "scope": "sc2:fal",
+                # "vin": vin,  << App uses a dedicated VIN here, but it works without, don't know
+            }
+            encoded_mbboauth_refresh_data = urlencode(
+                mbboauth_refresh_data, encoding="utf-8"
+            ).replace("+", "%20")
+            mbboauth_refresh_rsp, mbboauth_refresh_rsptxt = await self._api.request(
+                "POST",
+                self.mbbOAuthBaseURL + "/mobile/oauth2/v1/token",
+                encoded_mbboauth_refresh_data,
+                headers=headers,
+                allow_redirects=False,
+                cookies=mbboauth_client_reg_rsp.cookies,
+                rsp_wtxt=True,
+            )
+            # this code is the old "vwToken"
+            self.vwToken = json.loads(mbboauth_refresh_rsptxt)
+        else:
+            _LOGGER.debug(
+                "mbboauth: no refresh_token in auth response, using auth token directly as vwToken"
+            )
+            self.vwToken = mbboauth_auth_json
 
     def _generate_security_pin_hash(self, challenge: str) -> str:
         if self._spin is None:
@@ -1491,3 +1499,4 @@ class AudiService:
 
 
 __all__ = ["AudiService"]
+

--- a/readme.md
+++ b/readme.md
@@ -84,8 +84,8 @@ Normal updates retrieve data from the Audi Connect cloud service, and don't inte
 #### Parameters
 
 - **`vehicle`**: The Audi vehicle to perform the action on.
-> [!CAUTION]
-> **This service action counts against your daily API rate limit.** Repeated use may exhaust your limit. Use sparingly and monitor your remaining API calls via the **"API Requests Remaining"** diagnostic sensor or **Settings → System → Repairs & System Information**.
+  > [!CAUTION]
+  > **This service action counts against your daily API rate limit.** Repeated use may exhaust your limit. Use sparingly and monitor your remaining API calls via the **"API Requests Remaining"** diagnostic sensor or **Settings → System → Repairs & System Information**.
 
 ### Audi Connect: Refresh Cloud Data
 


### PR DESCRIPTION
## Problem

After a recent Audi/Cariad backend change, the MBB OAuth `/mobile/oauth2/v1/token` endpoint (`grant_type: id_token`) no longer returns a `refresh_token` in its initial auth response.

The login flow crashes at the final step:

```
KeyError: 'refresh_token'
File "audi_services.py", line 1464, in login_request
    "token": mbboauth_auth_json["refresh_token"],
```

This happens **after** all authentication steps complete successfully, so credentials are entirely valid — but the error surfaces as "Invalid Credentials". This is the root cause of #748.

## Fix

Make the immediate token refresh conditional on `refresh_token` being present in the auth response. If absent, use the auth token directly as `vwToken`.

The `refresh_token_if_necessary` method already handles the no-refresh-token case correctly (it guards with `if "refresh_token" not in self.mbboauthToken: return False`), so ongoing token renewal is unaffected.

## Testing

Confirmed working on v2.1.0, UK/EMEA region, Audi e-tron. Integration authenticates and loads all vehicle data successfully after this fix.