### PR TITLE
feat: Restore API requests remaining sensor state

### DIFF
--- a/custom_components/audiconnect/audi_api.py
+++ b/custom_components/audiconnect/audi_api.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 from asyncio import CancelledError, TimeoutError
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from aiohttp import ClientResponseError, ClientSession
@@ -33,6 +33,7 @@ class AudiAPI:
             {"http": proxy, "https": proxy} if proxy else None
         )
         self.vcf_remaining_calls: int | None = None
+        self.vcf_remaining_calls_last_observed: datetime | None = None
 
     def use_token(self, token: dict[str, Any] | None) -> None:
         self.__token = token
@@ -83,6 +84,7 @@ class AudiAPI:
                             remaining = None
                         if remaining is not None:
                             self.vcf_remaining_calls = remaining
+                            self.vcf_remaining_calls_last_observed = datetime.now(UTC)
                             if remaining < 10:
                                 _LOGGER.warning(
                                     "[VCF-RATE-LIMIT] Remaining calls: %d — warning: VCF call limit nearly exhausted",

--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -457,7 +458,7 @@ class AudiSensor(AudiEntity, SensorEntity):
         return None
 
 
-class AudiApiRateLimitSensor(AudiEntity, SensorEntity):
+class AudiApiRateLimitSensor(AudiEntity, RestoreSensor):
     """Account-level sensor exposing the Vcf-Remaining-Calls API rate limit."""
 
     _attr_name = "API requests remaining"
@@ -472,11 +473,61 @@ class AudiApiRateLimitSensor(AudiEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, vehicle)
         self._attr_unique_id = f"{entry_id}_api_requests_remaining"
+        self._restored_native_value: int | None = None
+        self._restored_last_observed: str | None = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        api = self.coordinator.account.connection._audi_service._api
+        if api.vcf_remaining_calls is not None:
+            return
+
+        if (restored := await self.async_get_last_sensor_data()) is not None:
+            value = restored.native_value
+            if isinstance(value, int) and not isinstance(value, bool):
+                self._restored_native_value = value
+
+        if (last_state := await self.async_get_last_state()) is None:
+            return
+
+        # Supports the first restart after upgrading from a version that did
+        # not previously store SensorExtraStoredData through RestoreSensor.
+        if self._restored_native_value is None and last_state.state.isdigit():
+            self._restored_native_value = int(last_state.state)
+
+        last_observed = last_state.attributes.get("last_observed")
+        if isinstance(last_observed, str):
+            self._restored_last_observed = last_observed
 
     @property
     def native_value(self) -> int | None:
         api = self.coordinator.account.connection._audi_service._api
-        return api.vcf_remaining_calls
+        if api.vcf_remaining_calls is not None:
+            return api.vcf_remaining_calls
+        return self._restored_native_value
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        api = self.coordinator.account.connection._audi_service._api
+        if api.vcf_remaining_calls_last_observed is not None:
+            return {
+                "last_observed": api.vcf_remaining_calls_last_observed.isoformat(),
+                # Avoid an attribute named "restored"; Home Assistant's frontend treats
+                # stateObj.attributes.restored as the marker for a restored/orphaned entity.
+                "value_restored": False,
+            }
+
+        if self._restored_native_value is None:
+            return {}
+
+        attrs: dict[str, Any] = {
+            # Avoid an attribute named "restored"; Home Assistant's frontend treats
+            # stateObj.attributes.restored as the marker for a restored/orphaned entity.
+            "value_restored": True,
+        }
+        if self._restored_last_observed is not None:
+            attrs["last_observed"] = self._restored_last_observed
+        return attrs
 
 
 __all__ = ["AudiApiRateLimitSensor", "AudiSensor", "async_setup_entry"]

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,9 @@ Normal updates retrieve data from the Audi Connect cloud service, and don't inte
 > [!CAUTION]
 > **This service action counts against your daily API rate limit.** Repeated use may exhaust your limit. Use sparingly and monitor your remaining API calls via the **"API Requests Remaining"** diagnostic sensor or **Settings → System → Repairs & System Information**.
 
+> [!NOTE]
+> The **"API Requests Remaining"** diagnostic sensor restores its last known value after a Home Assistant restart. Its `last_observed` attribute records when Audi last returned a `Vcf-Remaining-Calls` value. If `value_restored` is `true`, the displayed value was restored from the previous Home Assistant runtime and may no longer represent the current remaining allowance.
+
 ### Audi Connect: Refresh Cloud Data
 
 `audiconnect.refresh_cloud_data`


### PR DESCRIPTION
## Summary

Restore the last known value of the `API Requests Remaining` diagnostic sensor after a Home Assistant restart, and expose when the value was last genuinely observed from Audi.

Fixes #753

## Background

The `API Requests Remaining` sensor is useful for avoiding unnecessary vehicle refreshes and other remote operations. At present, the value is held only in memory, so after a Home Assistant restart the sensor becomes `unknown` until Audi next returns a `Vcf-Remaining-Calls` header.

That is inconvenient because obtaining a fresh counter value may itself require a quota-bearing Audi operation.

This PR keeps the existing diagnostic sensor, but makes its last known value restorable after restart and adds metadata to distinguish a restored value from a value freshly observed in the current Home Assistant runtime.

## Changes

* Record `vcf_remaining_calls_last_observed` when Audi returns a valid `Vcf-Remaining-Calls` header.
* Convert `AudiApiRateLimitSensor` to use Home Assistant's sensor restore support.
* Restore the last known numeric API request counter after Home Assistant restart.
* Add sensor attributes:

  * `last_observed`: timestamp at which Audi last supplied a `Vcf-Remaining-Calls` value;
  * `value_restored`: `true` when the displayed value was restored from the previous Home Assistant runtime and has not yet been replaced by a fresh observation.
* Document the restored-value semantics in the README.

## Rationale

A restored value is useful, but it should not be treated as definitely current. The remaining allowance may have changed outside Home Assistant, for example because of actions performed through the official myAudi app or because of quota replenishment/reset behaviour.

The `last_observed` and `value_restored` attributes make that distinction explicit:

* `value_restored: false` means the value was observed from Audi in the current runtime;
* `value_restored: true` means the value was restored from Home Assistant's previous state and may no longer represent the current allowance.

## Attribute naming

The restored-state flag is named `value_restored` rather than `restored`.

During local testing, using an attribute named `restored` caused Home Assistant's frontend to display the restored/orphaned-entity warning:

> This entity is no longer being provided by the integration.

This appears to be because Home Assistant's frontend treats a truthy `stateObj.attributes.restored` value as indicating a restored entity that is no longer being provided by an integration. See Home Assistant frontend issue:

https://github.com/home-assistant/frontend/issues/4401

Using `value_restored` avoids colliding with that frontend convention while still making the sensor semantics clear.

## Notes on quota behaviour

I have also been observing the counter behaviour while using Audi Connect v2.1.2.

A `refresh_cloud_data` action successfully performed a cloud update, but did not return a new `Vcf-Remaining-Calls` observation. The sensor value was re-reported by Home Assistant with the previously cached value, but no fresh quota observation was received.

I also have preliminary evidence that the counter may be shared with actions performed through the official myAudi app, but I have not attempted to document or model that in this PR. This PR intentionally does not add optimistic replenishment logic or broaden the documentation for quota-consuming service actions. Those would be better handled separately once the behaviour has been observed more rigorously.

## Testing

Tested locally with:

* Audi Connect v2.1.2
* Home Assistant Container
* UK / EMEA Audi account
* Audi Q8 50 e-tron
* API level 1

Local checks:

* Ran `python -m compileall custom_components/audiconnect`
* Ran `pre-commit run --files custom_components/audiconnect/audi_api.py custom_components/audiconnect/sensor.py readme.md`

Functional testing in Home Assistant Container:

1. Installed the patched `audi_api.py` and `sensor.py`.
2. Performed one `refresh_vehicle_data` action.
3. Confirmed `API Requests Remaining` reported a numeric value with:

   * `value_restored: false`
   * populated `last_observed`
4. Restarted Home Assistant.
5. Confirmed the same numeric value was restored with:

   * `value_restored: true`
   * previous `last_observed` preserved
6. Confirmed that using the attribute name `restored` caused Home Assistant's restored/orphaned-entity warning, and that renaming the attribute to `value_restored` avoided that warning.
7. Confirmed `refresh_cloud_data` did not falsely clear the restored-state metadata when Audi did not return a new `Vcf-Remaining-Calls` value.
