### PR TITLE
fix: Update device_tracker.py

### DIFF
--- a/custom_components/audiconnect/device_tracker.py
+++ b/custom_components/audiconnect/device_tracker.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import TrackerEntity
+from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback


### PR DESCRIPTION
Fix deprecated importing TrackerEntity and SourceType. I found the fix [here](https://github.com/Hyundai-Kia-Connect/kia_uvo/pull/1689)

- Update TrackerEntity import from homeassistant.components.device_tracker.config_entry to homeassistant.components.device_tracker
- Update SourceType import from homeassistant.components.device_tracker to homeassistant.components.device_tracker.const

This solves issue [#744](https://github.com/audiconnect/audi_connect_ha/issues/744)

If you have any recommendations about my pull request, please let me know. I'm not a developer but try to fix small issues if possible :-)