### PR TITLE
fix: update `plug_state` to account for `invalid` state in home zone

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1905,7 +1905,7 @@ class AudiConnectVehicle:
         """Return plug state"""
         if self.plug_state_supported:
             check = self._vehicle.state.get("plugState")
-            return check != "disconnected"
+            return check not in ("invalid", "disconnected")
 
     @property
     def plug_state_supported(self):


### PR DESCRIPTION
In the home zone, the vehicle can sometimes return `invalid` state when not plugged in. When leaving the home zone the vehicle properly reports `disconnected`.

This fix will set the state of the `Plug State` sensor to `Unplugged` if in `invalid` state.