### PR TITLE
feat!: device-code login to fix auth broken by Play Integrity attestation

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
@@ -33,7 +34,10 @@ from .audi_account import (
 from .const import (
     CONF_API_LEVEL,
     CONF_DEVICE_ID,
+    CONF_PASSWORD,
+    CONF_REFRESH_TOKEN,
     CONF_SCAN_INITIAL,
+    CONF_USERNAME,
     DEFAULT_API_LEVEL,
     DOMAIN,
     PLATFORMS,
@@ -88,6 +92,17 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             config_entry, version=2, data=new_data, options=new_options
         )
 
+    if config_entry.version == 2:
+        # v2 -> v3:
+        # Authentication moved from username/password (retired by Audi's move to
+        # Play Integrity attestation on the token exchange) to the OAuth Device
+        # Authorization Grant. Drop the stored credentials; the entry has no refresh
+        # token yet, so setup will start a reauthentication (device-code login).
+        new_data = {**config_entry.data}
+        new_data.pop(CONF_PASSWORD, None)
+        new_data.pop(CONF_USERNAME, None)
+        hass.config_entries.async_update_entry(config_entry, version=3, data=new_data)
+
     _LOGGER.info("Migration to version %s successful", config_entry.version)
     return True
 
@@ -98,6 +113,7 @@ class AudiRuntimeData:
 
     account: AudiAccount
     coordinator: AudiDataUpdateCoordinator
+    options_snapshot: dict[str, Any] = field(default_factory=dict)
 
 
 def _resolve_device_to_vin(hass: HomeAssistant, device_id: str) -> str | None:
@@ -157,6 +173,12 @@ def _get_all_coordinators(hass: HomeAssistant) -> list[AudiDataUpdateCoordinator
 async def _async_update_listener(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> None:
+    runtime_data: AudiRuntimeData | None = getattr(config_entry, "runtime_data", None)
+    if runtime_data is not None and runtime_data.options_snapshot == dict(
+        config_entry.options
+    ):
+        # Only entry data changed (e.g. a rotated refresh token); no reload needed.
+        return
     await hass.config_entries.async_reload(config_entry.entry_id)
 
 
@@ -308,6 +330,12 @@ def _async_cleanup_orphaned_devices(
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Audi Connect from a config entry."""
+    if not config_entry.data.get(CONF_REFRESH_TOKEN):
+        # No stored authorization (fresh v2->v3 migration): prompt device-code login.
+        raise ConfigEntryAuthFailed(
+            "Audi Connect needs to sign in again using device-code login"
+        )
+
     account = AudiAccount(hass, config_entry)
     coordinator = AudiDataUpdateCoordinator.from_entry(hass, account, config_entry)
 
@@ -316,7 +344,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     account.set_refresh_callback(_request_refresh)
     config_entry.runtime_data = AudiRuntimeData(
-        account=account, coordinator=coordinator
+        account=account,
+        coordinator=coordinator,
+        options_snapshot=dict(config_entry.options),
     )
 
     config_entry.async_on_unload(

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -9,9 +9,14 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .audi_connect_account import AudiConnectAccount, AudiConnectObserver
+from .audi_connect_account import (
+    AudiAuthError,
+    AudiConnectAccount,
+    AudiConnectObserver,
+)
 from .audi_models import VehicleData
 from .const import (
     CONF_ACTION,
@@ -33,8 +38,7 @@ from .const import (
     CONF_UPDATE_SLEEP,
     CONF_SPIN,
     CONF_TARGET_SOC,
-    CONF_PASSWORD,
-    CONF_USERNAME,
+    CONF_REFRESH_TOKEN,
     DEFAULT_API_LEVEL,
     DOMAIN,
     REFRESH_VEHICLE_DATA_COMPLETED_EVENT,
@@ -118,17 +122,26 @@ class AudiAccount(AudiConnectObserver):
 
         self.connection = AudiConnectAccount(
             session=session,
-            username=self.config_entry.data.get(CONF_USERNAME),
-            password=self.config_entry.data.get(CONF_PASSWORD),
             country=self.config_entry.data.get(CONF_REGION),
             spin=self.config_entry.data.get(CONF_SPIN),
             api_level=self.config_entry.data.get(CONF_API_LEVEL, DEFAULT_API_LEVEL),
             excluded_vins=excluded_vins,
+            refresh_token=self.config_entry.data.get(CONF_REFRESH_TOKEN),
         )
         self.connection.add_observer(self)
+        self.connection.set_refresh_token_listener(self._persist_refresh_token)
 
     def set_refresh_callback(self, callback: Callable[[], Any]) -> None:
         self._refresh_callback = callback
+
+    def _persist_refresh_token(self, refresh_token: str) -> None:
+        """Persist a rotated IDK refresh token back to the config entry."""
+        if self.config_entry.data.get(CONF_REFRESH_TOKEN) == refresh_token:
+            return
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={**self.config_entry.data, CONF_REFRESH_TOKEN: refresh_token},
+        )
 
     def _build_vehicle_data(self, vehicle: Any) -> VehicleData:
         cfg_vehicle = VehicleData(self.config_entry)
@@ -138,7 +151,11 @@ class AudiAccount(AudiConnectObserver):
     async def async_refresh_data(self) -> list[VehicleData]:
         """Refresh cloud data and update discovered vehicles."""
         _LOGGER.debug("Starting refresh cloud data...")
-        if not await self.connection.update(None):
+        try:
+            updated = await self.connection.update(None)
+        except AudiAuthError as err:
+            raise ConfigEntryAuthFailed(str(err)) from err
+        if not updated:
             _LOGGER.warning("Failed refresh cloud data")
             raise RuntimeError("Failed refresh cloud data")
 

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -13,7 +13,7 @@ from typing import Any
 from aiohttp import ClientResponseError, ClientSession
 
 from .audi_api import AudiAPI
-from .audi_services import AudiService
+from .audi_services import AudiAuthError, AudiService
 from .util import get_attr, log_exception, parse_datetime, parse_float, parse_int
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,10 +27,6 @@ ACTION_CHARGER = "charger"
 ACTION_WINDOW_HEATING = "window_heating"
 ACTION_PRE_HEATER = "pre_heater"
 ACTION_ENGINE = "engine"
-
-
-class AudiAuthError(Exception):
-    """Raised when the stored authorization is missing or no longer valid."""
 
 
 class AudiConnectObserver(ABC):
@@ -144,6 +140,10 @@ class AudiConnectAccount:
                     self._on_refresh_token_update(new_refresh_token)
             _LOGGER.debug("LOGIN: Audi session established")
             return True
+        except AudiAuthError:
+            # Token rejected (expired/revoked): propagate so Home Assistant reauth
+            # is triggered instead of retrying a credential that can never work.
+            raise
         except Exception as exception:
             if logError is True:
                 _LOGGER.error(

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -6,6 +6,7 @@ import re
 import time
 from abc import ABC, abstractmethod
 from asyncio import TimeoutError
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -28,6 +29,10 @@ ACTION_PRE_HEATER = "pre_heater"
 ACTION_ENGINE = "engine"
 
 
+class AudiAuthError(Exception):
+    """Raised when the stored authorization is missing or no longer valid."""
+
+
 class AudiConnectObserver(ABC):
     @abstractmethod
     async def handle_notification(self, vin: str, action: str) -> None:
@@ -40,18 +45,16 @@ class AudiConnectAccount:
     def __init__(
         self,
         session: ClientSession,
-        username: str,
-        password: str,
         country: str,
         spin: str | None,
         api_level: int,
         excluded_vins: list[str] | None = None,
+        refresh_token: str | None = None,
     ) -> None:
         self._api = AudiAPI(session)
         self._audi_service = AudiService(self._api, country, spin, api_level)
 
-        self._username = username
-        self._password = password
+        self._refresh_token = refresh_token
         self._loggedin = False
         self._support_vehicle_refresh = True
         self._logintime: float = 0
@@ -60,12 +63,46 @@ class AudiConnectAccount:
         self._connect_delay = 10
 
         self._update_listeners: list[Any] = []
+        self._on_refresh_token_update: Callable[[str], None] | None = None
 
         self._vehicles: list[AudiConnectVehicle] = []
         self._audi_vehicles: list[Any] = []
         self._excluded_vins = [v.lower() for v in (excluded_vins or [])]
 
         self._observers: list[AudiConnectObserver] = []
+
+    @property
+    def refresh_token(self) -> str | None:
+        """Return the current IDK refresh token."""
+        return self._refresh_token
+
+    def account_identifier(self) -> str | None:
+        """Return a stable identifier for the signed-in account."""
+        return self._audi_service.get_id_token_subject()
+
+    def set_refresh_token_listener(self, callback: Callable[[str], None]) -> None:
+        """Register a callback invoked with the new refresh token when it rotates."""
+        self._on_refresh_token_update = callback
+
+    def _sync_refresh_token(self) -> None:
+        new_token = self._audi_service.current_refresh_token()
+        if new_token and new_token != self._refresh_token:
+            self._refresh_token = new_token
+            if self._on_refresh_token_update is not None:
+                self._on_refresh_token_update(new_token)
+
+    async def request_device_code(self) -> dict[str, Any]:
+        """Start the device authorization grant (used by config/reauth flow)."""
+        return await self._audi_service.request_device_code()
+
+    async def poll_device_token(self, device_code: str) -> str:
+        """Poll once for device-code approval; capture the session on success."""
+        status = await self._audi_service.poll_device_token(device_code)
+        if status == "ok":
+            self._loggedin = True
+            self._logintime = time.time()
+            self._sync_refresh_token()
+        return status
 
     @property
     def vehicles(self) -> list[AudiConnectVehicle]:
@@ -80,6 +117,8 @@ class AudiConnectAccount:
             await observer.handle_notification(vin, action)
 
     async def login(self):
+        if not self._refresh_token:
+            raise AudiAuthError("No stored authorization; reauthentication is required")
         for i in range(self._connect_retries):
             self._loggedin = await self.try_login(i == self._connect_retries - 1)
             if self._loggedin is True:
@@ -95,17 +134,22 @@ class AudiConnectAccount:
 
     async def try_login(self, logError):
         try:
-            _LOGGER.debug("LOGIN: Requesting login to Audi service...")
-            await self._audi_service.login(self._username, self._password, False)
-            _LOGGER.debug("LOGIN: Login to Audi service successful")
+            _LOGGER.debug("LOGIN: Refreshing Audi session from stored token...")
+            new_refresh_token = await self._audi_service.login_with_refresh_token(
+                self._refresh_token
+            )
+            if new_refresh_token and new_refresh_token != self._refresh_token:
+                self._refresh_token = new_refresh_token
+                if self._on_refresh_token_update is not None:
+                    self._on_refresh_token_update(new_refresh_token)
+            _LOGGER.debug("LOGIN: Audi session established")
             return True
         except Exception as exception:
             if logError is True:
                 _LOGGER.error(
-                    "LOGIN: Failed to log in to the Audi service: %s. "
-                    "If this error persists, open the myAudi app or log in via "
-                    "a web browser and accept any pending terms or consent prompts, "
-                    "then restart the integration.",
+                    "LOGIN: Failed to establish an Audi session: %s. "
+                    "Your stored authorization may have expired; reconfigure the "
+                    "Audi Connect integration to sign in again.",
                     str(exception),
                 )
             return False
@@ -122,6 +166,7 @@ class AudiConnectAccount:
         if await self._audi_service.refresh_token_if_necessary(elapsed_sec):
             # Store current timestamp when refresh was performed and successful
             self._logintime = time.time()
+            self._sync_refresh_token()
 
         """Update the state of all vehicles."""
         try:

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -26,9 +26,10 @@ FAILED = "failed"
 REQUEST_SUCCESSFUL = "request_successful"
 REQUEST_FAILED = "request_failed"
 
-# Scope requested for the Device Authorization Grant. Verified sufficient for the
-# CARIAD BFF vehicle endpoints (lock/unlock, climate, charging, status).
-DEVICE_CODE_SCOPE = "openid profile badge cars dealers vin"
+# Scope requested for the Device Authorization Grant. "mbb" is required for the
+# legacy MBB / fs-car endpoints (lock/unlock, trip statistics, climater); the
+# other scopes cover account identity and the CARIAD BFF vehicle data.
+DEVICE_CODE_SCOPE = "openid mbb profile badge cars dealers vin"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -5,13 +5,10 @@ import base64
 import hmac
 import json
 import logging
-import os
-import re
-import uuid
 from datetime import datetime, timedelta, timezone
-from hashlib import sha256, sha512
+from hashlib import sha512
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 
 from bs4 import BeautifulSoup
 
@@ -28,6 +25,10 @@ SUCCEEDED = "succeeded"
 FAILED = "failed"
 REQUEST_SUCCESSFUL = "request_successful"
 REQUEST_FAILED = "request_failed"
+
+# Scope requested for the Device Authorization Grant. Verified sufficient for the
+# CARIAD BFF vehicle endpoints (lock/unlock, climate, charging, status).
+DEVICE_CODE_SCOPE = "openid profile badge cars dealers vin"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,10 +93,6 @@ class AudiService:
         else:
             raise ValueError("Unknown form action: " + action)
         return username_post_url
-
-    async def login(self, user: str, password: str, persist_token: bool = True) -> None:
-        _LOGGER.debug("LOGIN: Starting login to Audi service...")
-        await self.login_request(user, password)
 
     async def refresh_vehicle_data(self, vin: str):
         request_id = await self.request_current_vehicle_data(vin.upper())
@@ -1101,7 +1098,6 @@ class AudiService:
             headers = {
                 "Accept": "application/json",
                 "Accept-Charset": "utf-8",
-                "X-QMAuth": self._calculate_X_QMAuth(),
                 "User-Agent": AudiAPI.HDR_USER_AGENT,
                 "Content-Type": "application/x-www-form-urlencoded",
             }
@@ -1158,8 +1154,13 @@ class AudiService:
             _LOGGER.error("Refresh token failed: " + str(exception))
             return False
 
-    # TR/2021-12-01 updated to match behaviour of Android myAudi 4.5.0
-    async def login_request(self, user: str, password: str):
+    async def _discover_endpoints(self) -> None:
+        """Resolve the dynamic client id and OIDC endpoints.
+
+        Fetches the market configuration and the IDK openid-configuration and
+        stores the client id, token endpoint, AZS/mbboauth base URLs and the
+        device-authorization endpoint on the instance.
+        """
         self._api.use_token(None)
         self._api.set_xclient_id(None)
         self.xclientId = None
@@ -1205,191 +1206,164 @@ class AudiService:
 
         if "idkLoginServiceConfigurationURLProduction" in marketcfg_json:
             openidcfg_url = marketcfg_json["idkLoginServiceConfigurationURLProduction"]
-            _LOGGER.debug(
-                "Using idkLoginServiceConfigurationURLProduction from market config: %s",
-                openidcfg_url,
-            )
-        else:
-            _LOGGER.debug(
-                "idkLoginServiceConfigurationURLProduction not found in market config, "
-                "falling back to CARIAD default: %s",
-                openidcfg_url,
-            )
 
         # get openId config
         openidcfg_json = await self._api.request("GET", openidcfg_url, None)
 
-        # use dynamic config from openId config
-        authorization_endpoint = "https://identity.vwgroup.io/oidc/v1/authorize"
-        if "authorization_endpoint" in openidcfg_json:
-            authorization_endpoint = openidcfg_json["authorization_endpoint"]
-
         self._tokenEndpoint = self.__get_cariad_url("/auth/v1/idk/oidc/token")
-
         if "token_endpoint" in openidcfg_json:
             self._tokenEndpoint = openidcfg_json["token_endpoint"]
-        # revocation_endpoint = self.__get_cariad_base_url("/login/v1/idk/revoke")
-        # if "revocation_endpoint" in openidcfg_json:
-        # revocation_endpoint = openidcfg_json["revocation_endpoint"]
 
-        # generate code_challenge
-        code_verifier = str(base64.urlsafe_b64encode(os.urandom(32)), "utf-8").strip(
-            "="
+        # Device Authorization Grant (RFC 8628) endpoint. Discovery advertises it;
+        # fall back to the well-known global identity endpoint.
+        self._deviceAuthorizationEndpoint = (
+            "https://identity.vwgroup.io/oidc/v1/device_authorization"
         )
-        code_challenge = str(
-            base64.urlsafe_b64encode(
-                sha256(code_verifier.encode("ascii", "ignore")).digest()
-            ),
-            "utf-8",
-        ).strip("=")
-        code_challenge_method = "S256"
+        if "device_authorization_endpoint" in openidcfg_json:
+            self._deviceAuthorizationEndpoint = openidcfg_json[
+                "device_authorization_endpoint"
+            ]
 
-        #
-        state = str(uuid.uuid4())
-        nonce = str(uuid.uuid4())
+    async def request_device_code(self) -> dict[str, Any]:
+        """Start the OAuth Device Authorization Grant (RFC 8628).
 
-        # login page
+        Returns the response containing ``user_code``, ``verification_uri`` /
+        ``verification_uri_complete``, ``device_code``, ``interval`` and
+        ``expires_in``. The user approves the ``user_code`` in a browser. This
+        grant does not require a Play Integrity attestation header.
+        """
+        await self._discover_endpoints()
         headers = {
             "Accept": "application/json",
             "Accept-Charset": "utf-8",
             "X-App-Version": AudiAPI.HDR_XAPP_VERSION,
             "X-App-Name": "myAudi",
             "User-Agent": AudiAPI.HDR_USER_AGENT,
+            "Content-Type": "application/x-www-form-urlencoded",
         }
-        idk_data = {
-            "response_type": "code",
-            "client_id": self._client_id,
-            "redirect_uri": "myaudi:///",
-            "scope": "address profile badge birthdate birthplace nationalIdentifier nationality profession email vin phone nickname name picture mbb gallery openid",
-            "state": state,
-            "nonce": nonce,
-            "prompt": "login",
-            "code_challenge": code_challenge,
-            "code_challenge_method": code_challenge_method,
-            "ui_locales": "de-de de",
-        }
-        idk_rsp, idk_rsptxt = await self._api.request(
-            "GET",
-            authorization_endpoint,
-            None,
-            headers=headers,
-            params=idk_data,
-            rsp_wtxt=True,
-        )
-
-        # form_data with email
-        submit_data = self.get_hidden_html_input_form_data(idk_rsptxt, {"email": user})
-        submit_url = self.get_post_url(idk_rsptxt, authorization_endpoint)
-        # send email
-        email_rsp, email_rsptxt = await self._api.request(
+        data = {"client_id": self._client_id, "scope": DEVICE_CODE_SCOPE}
+        encoded = urlencode(data, encoding="utf-8").replace("+", "%20")
+        _rsp, rsptxt = await self._api.request(
             "POST",
-            submit_url,
-            submit_data,
+            self._deviceAuthorizationEndpoint,
+            encoded,
             headers=headers,
-            cookies=idk_rsp.cookies,
-            allow_redirects=True,
-            rsp_wtxt=True,
-        )
-
-        # form_data with password
-        # 2022-01-29: new HTML response uses a js two build the html form data + button.
-        #             Therefore it's not possible to extract hmac and other form data.
-        #             --> extract hmac from embedded js snippet.
-        regex_res = re.findall('"hmac"\\s*:\\s*"[0-9a-fA-F]+"', email_rsptxt)
-        if regex_res:
-            submit_url = submit_url.replace("identifier", "authenticate")
-            submit_data["hmac"] = regex_res[0].split(":")[1].strip('"')
-            submit_data["password"] = password
-        else:
-            submit_data = self.get_hidden_html_input_form_data(
-                email_rsptxt, {"password": password}
-            )
-            submit_url = self.get_post_url(email_rsptxt, submit_url)
-
-        # send password
-        pw_rsp, pw_rsptxt = await self._api.request(
-            "POST",
-            submit_url,
-            submit_data,
-            headers=headers,
-            cookies=idk_rsp.cookies,
             allow_redirects=False,
             rsp_wtxt=True,
         )
-
-        # forward1 after pwd
-        if "Location" not in pw_rsp.headers:
+        result = json.loads(rsptxt)
+        if "device_code" not in result:
             raise Exception(
-                "Login redirect missing after password submission (HTTP %d). "
-                "Audi may be showing a consent or terms-of-service prompt. "
-                "Please log in to myAudi via a browser or the myAudi app and "
-                "accept any pending agreements, then restart the integration."
-                % pw_rsp.status
+                "Device authorization request failed: "
+                + str(result.get("error", rsptxt[:200]))
             )
-        fwd1_rsp, fwd1_rsptxt = await self._api.request(
-            "GET",
-            pw_rsp.headers["Location"],
-            None,
-            headers=headers,
-            cookies=idk_rsp.cookies,
-            allow_redirects=False,
-            rsp_wtxt=True,
-        )
-        # forward2 after pwd
-        fwd2_rsp, fwd2_rsptxt = await self._api.request(
-            "GET",
-            fwd1_rsp.headers["Location"],
-            None,
-            headers=headers,
-            cookies=idk_rsp.cookies,
-            allow_redirects=False,
-            rsp_wtxt=True,
-        )
-        # get tokens
-        codeauth_rsp, codeauth_rsptxt = await self._api.request(
-            "GET",
-            fwd2_rsp.headers["Location"],
-            None,
-            headers=headers,
-            cookies=fwd2_rsp.cookies,
-            allow_redirects=False,
-            rsp_wtxt=True,
-        )
-        authcode_parsed = urlparse(
-            codeauth_rsp.headers["Location"][len("myaudi:///?") :]
-        )
-        authcode_strings = parse_qs(authcode_parsed.path)
+        return result
 
-        # hdr
+    async def poll_device_token(self, device_code: str) -> str:
+        """Poll the token endpoint once for a device_code grant.
+
+        Returns one of ``"ok"``, ``"authorization_pending"``, ``"slow_down"``,
+        ``"expired"``, ``"denied"`` or ``"error"``. On ``"ok"`` the IDK bearer
+        token is stored and the AZS + mbboauth session tokens are derived. No
+        attestation header is sent.
+        """
         headers = {
             "Accept": "application/json",
             "Accept-Charset": "utf-8",
-            "X-QMAuth": self._calculate_X_QMAuth(),
             "User-Agent": AudiAPI.HDR_USER_AGENT,
             "Content-Type": "application/x-www-form-urlencoded",
         }
-        # IDK token request data
-        tokenreq_data = {
+        data = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
             "client_id": self._client_id,
-            "grant_type": "authorization_code",
-            "code": authcode_strings["code"][0],
-            "redirect_uri": "myaudi:///",
-            "response_type": "token id_token",
-            "code_verifier": code_verifier,
+            "device_code": device_code,
         }
-        # IDK token request
-        encoded_tokenreq_data = urlencode(tokenreq_data, encoding="utf-8").replace(
-            "+", "%20"
-        )
-        bearer_token_rsp, bearer_token_rsptxt = await self._api.request(
+        encoded = urlencode(data, encoding="utf-8").replace("+", "%20")
+        _rsp, rsptxt = await self._api.request(
             "POST",
             self._tokenEndpoint,
-            encoded_tokenreq_data,
+            encoded,
             headers=headers,
             allow_redirects=False,
             rsp_wtxt=True,
         )
-        self._bearer_token_json = json.loads(bearer_token_rsptxt)
+        result = json.loads(rsptxt)
+        if "access_token" in result:
+            self._bearer_token_json = result
+            await self._finalize_session()
+            return "ok"
+        error = result.get("error")
+        mapping = {
+            "authorization_pending": "authorization_pending",
+            "slow_down": "slow_down",
+            "expired_token": "expired",
+            "access_denied": "denied",
+        }
+        if error in mapping:
+            return mapping[error]
+        _LOGGER.debug("Unexpected device token response: %s", rsptxt[:200])
+        return "error"
+
+    async def login_with_refresh_token(self, refresh_token: str) -> str:
+        """Obtain a session from a stored IDK refresh token.
+
+        Uses the standard ``refresh_token`` grant, which needs no Play Integrity
+        attestation. Returns the (possibly rotated) refresh token to persist.
+        """
+        await self._discover_endpoints()
+        headers = {
+            "Accept": "application/json",
+            "Accept-Charset": "utf-8",
+            "User-Agent": AudiAPI.HDR_USER_AGENT,
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        data = {
+            "client_id": self._client_id,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "response_type": "token id_token",
+        }
+        encoded = urlencode(data, encoding="utf-8").replace("+", "%20")
+        _rsp, rsptxt = await self._api.request(
+            "POST",
+            self._tokenEndpoint,
+            encoded,
+            headers=headers,
+            allow_redirects=False,
+            rsp_wtxt=True,
+        )
+        result = json.loads(rsptxt)
+        if "access_token" not in result:
+            raise Exception(
+                "Token refresh failed: " + str(result.get("error", rsptxt[:200]))
+            )
+        self._bearer_token_json = result
+        await self._finalize_session()
+        return self._bearer_token_json.get("refresh_token", refresh_token)
+
+    def current_refresh_token(self) -> str | None:
+        """Return the current IDK refresh token (rotates on each refresh)."""
+        if self._bearer_token_json is None:
+            return None
+        return self._bearer_token_json.get("refresh_token")
+
+    def get_id_token_subject(self) -> str | None:
+        """Return a stable account identifier (email or sub) from the id token."""
+        if self._bearer_token_json is None:
+            return None
+        id_token = self._bearer_token_json.get("id_token")
+        if not id_token:
+            return None
+        try:
+            segment = id_token.split(".")[1]
+            segment += "=" * (-len(segment) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(segment))
+        except (ValueError, IndexError, json.JSONDecodeError):
+            return None
+        return payload.get("email") or payload.get("sub")
+
+    async def _finalize_session(self) -> None:
+        """Derive the AZS and mbboauth tokens from the current IDK bearer token."""
 
         # AZS token
         headers = {

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -33,6 +33,10 @@ DEVICE_CODE_SCOPE = "openid profile badge cars dealers vin"
 _LOGGER = logging.getLogger(__name__)
 
 
+class AudiAuthError(Exception):
+    """Raised when authorization is missing or a token has been rejected."""
+
+
 def _to_absolute(absolute_url: str, relative_url: str) -> str:
     """Convert a relative url to an absolute url."""
     url_parts = urlparse(absolute_url)
@@ -1120,7 +1124,13 @@ class AudiService:
                 allow_redirects=False,
                 rsp_wtxt=True,
             )
-            self._bearer_token_json = json.loads(bearer_token_rsptxt)
+            refreshed = json.loads(bearer_token_rsptxt)
+            if "access_token" not in refreshed:
+                raise AudiAuthError(
+                    "IDK refresh rejected: "
+                    + str(refreshed.get("error", bearer_token_rsptxt[:200]))
+                )
+            self._bearer_token_json = refreshed
 
             # AZS token
             headers = {
@@ -1150,6 +1160,8 @@ class AudiService:
 
             return True
 
+        except AudiAuthError:
+            raise
         except Exception as exception:
             _LOGGER.error("Refresh token failed: " + str(exception))
             return False
@@ -1334,8 +1346,8 @@ class AudiService:
         )
         result = json.loads(rsptxt)
         if "access_token" not in result:
-            raise Exception(
-                "Token refresh failed: " + str(result.get("error", rsptxt[:200]))
+            raise AudiAuthError(
+                "Token refresh rejected: " + str(result.get("error", rsptxt[:200]))
             )
         self._bearer_token_json = result
         await self._finalize_session()

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -136,7 +136,12 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
             self._user_code = response.get("user_code")
 
         if user_input is not None:
-            status = await self._connection.poll_device_token(self._device_code)
+            try:
+                status = await self._connection.poll_device_token(self._device_code)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Audi device token poll failed")
+                status = None
+                errors["base"] = "device_auth_failed"
             if status == "ok":
                 return await self._finish_device_login()
             if status in ("authorization_pending", "slow_down"):
@@ -145,7 +150,7 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Code timed out; mint a fresh one and show it again.
                 self._device_code = None
                 return await self.async_step_device()
-            else:
+            elif status is not None:
                 errors["base"] = "device_auth_failed"
 
         step_id = "reauth_confirm" if self._reauth_entry is not None else "device"
@@ -162,6 +167,9 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _finish_device_login(self) -> ConfigFlowResult:
         assert self._connection is not None
         refresh_token = self._connection.refresh_token
+        if not refresh_token:
+            # Approved but no refresh token issued; do not persist a dead entry.
+            return self.async_abort(reason="device_auth_failed")
 
         if self._reauth_entry is not None:
             return self.async_update_reload_and_abort(
@@ -172,11 +180,12 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        identifier = self._connection.account_identifier() or "audi"
-        await self.async_set_unique_id(identifier.lower())
-        self._abort_if_unique_id_configured()
+        identifier = self._connection.account_identifier()
+        if identifier:
+            await self.async_set_unique_id(identifier.lower())
+            self._abort_if_unique_id_configured()
         return self.async_create_entry(
-            title=identifier,
+            title=identifier or "Audi Connect",
             data={**self._flow_data, CONF_REFRESH_TOKEN: refresh_token},
         )
 

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
@@ -26,14 +27,13 @@ from .const import (
     API_LEVELS,
     CONF_API_LEVEL,
     CONF_FILTER_VINS,
-    CONF_PASSWORD,
     CONF_REFRESH_AFTER_ACTION,
+    CONF_REFRESH_TOKEN,
     CONF_REGION,
     CONF_SCAN_INITIAL,
     CONF_SCAN_INTERVAL,
     CONF_SPIN,
     CONF_UPDATE_SLEEP,
-    CONF_USERNAME,
     DEFAULT_API_LEVEL,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
@@ -49,58 +49,44 @@ REGION_REVERSE = {v: k for k, v in REGIONS.items()}
 
 
 class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
-    VERSION = 2
+    VERSION = 3
+
+    def __init__(self) -> None:
+        self._flow_data: dict[str, Any] = {}
+        self._connection: AudiConnectAccount | None = None
+        self._device_code: str | None = None
+        self._verification_uri: str | None = None
+        self._user_code: str | None = None
+        self._reauth_entry: ConfigEntry | None = None
+
+    def _build_connection(self) -> AudiConnectAccount:
+        session = async_get_clientsession(self.hass)
+        return AudiConnectAccount(
+            session=session,
+            country=self._flow_data[CONF_REGION],
+            spin=self._flow_data.get(CONF_SPIN),
+            api_level=self._flow_data.get(CONF_API_LEVEL, DEFAULT_API_LEVEL),
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        errors: dict[str, str] = {}
-
         if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
-            self._abort_if_unique_id_configured()
-
-            region = REGION_OPTIONS[user_input[CONF_REGION]]
-
-            try:
-                session = async_get_clientsession(self.hass)
-                connection = AudiConnectAccount(
-                    session=session,
-                    username=user_input[CONF_USERNAME],
-                    password=user_input[CONF_PASSWORD],
-                    country=region,
-                    spin=user_input.get(CONF_SPIN),
-                    api_level=int(user_input[CONF_API_LEVEL]),
-                )
-                if not await connection.try_login(False):
-                    errors["base"] = "invalid_credentials"
-                else:
-                    return self.async_create_entry(
-                        title=user_input[CONF_USERNAME],
-                        data={
-                            CONF_USERNAME: user_input[CONF_USERNAME],
-                            CONF_PASSWORD: user_input[CONF_PASSWORD],
-                            CONF_SPIN: user_input.get(CONF_SPIN),
-                            CONF_REGION: region,
-                            CONF_SCAN_INTERVAL: max(
-                                user_input.get(
-                                    CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
-                                ),
-                                MIN_UPDATE_INTERVAL,
-                            ),
-                            CONF_API_LEVEL: int(user_input[CONF_API_LEVEL]),
-                        },
-                    )
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("Audi config flow failed")
-                errors["base"] = "unexpected"
+            self._flow_data = {
+                CONF_REGION: REGION_OPTIONS[user_input[CONF_REGION]],
+                CONF_SPIN: user_input.get(CONF_SPIN),
+                CONF_API_LEVEL: int(user_input[CONF_API_LEVEL]),
+                CONF_SCAN_INTERVAL: max(
+                    int(user_input.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL)),
+                    MIN_UPDATE_INTERVAL,
+                ),
+            }
+            return await self.async_step_device()
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,
                     vol.Optional(CONF_SPIN): str,
                     vol.Required(CONF_REGION, default="1"): SelectSelector(
                         SelectSelectorConfig(
@@ -126,46 +112,106 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                 }
             ),
+        )
+
+    async def async_step_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Device Authorization Grant: show a code/URL, then poll for approval."""
+        errors: dict[str, str] = {}
+
+        if self._connection is None:
+            self._connection = self._build_connection()
+
+        if self._device_code is None:
+            try:
+                response = await self._connection.request_device_code()
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Audi device authorization request failed")
+                return self.async_abort(reason="device_auth_failed")
+            self._device_code = response["device_code"]
+            self._verification_uri = response.get(
+                "verification_uri_complete"
+            ) or response.get("verification_uri")
+            self._user_code = response.get("user_code")
+
+        if user_input is not None:
+            status = await self._connection.poll_device_token(self._device_code)
+            if status == "ok":
+                return await self._finish_device_login()
+            if status in ("authorization_pending", "slow_down"):
+                errors["base"] = "authorization_pending"
+            elif status == "expired":
+                # Code timed out; mint a fresh one and show it again.
+                self._device_code = None
+                return await self.async_step_device()
+            else:
+                errors["base"] = "device_auth_failed"
+
+        step_id = "reauth_confirm" if self._reauth_entry is not None else "device"
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "verification_uri": self._verification_uri or "",
+                "user_code": self._user_code or "",
+            },
             errors=errors,
         )
+
+    async def _finish_device_login(self) -> ConfigFlowResult:
+        assert self._connection is not None
+        refresh_token = self._connection.refresh_token
+
+        if self._reauth_entry is not None:
+            return self.async_update_reload_and_abort(
+                self._reauth_entry,
+                data={
+                    **self._reauth_entry.data,
+                    CONF_REFRESH_TOKEN: refresh_token,
+                },
+            )
+
+        identifier = self._connection.account_identifier() or "audi"
+        await self.async_set_unique_id(identifier.lower())
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=identifier,
+            data={**self._flow_data, CONF_REFRESH_TOKEN: refresh_token},
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        self._reauth_entry = self._get_reauth_entry()
+        self._flow_data = {
+            CONF_REGION: self._reauth_entry.data.get(CONF_REGION),
+            CONF_SPIN: self._reauth_entry.data.get(CONF_SPIN),
+            CONF_API_LEVEL: self._reauth_entry.data.get(
+                CONF_API_LEVEL, DEFAULT_API_LEVEL
+            ),
+        }
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        return await self.async_step_device(user_input)
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        errors: dict[str, str] = {}
         reconfigure_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            password = user_input[CONF_PASSWORD]
-            spin = user_input.get(CONF_SPIN)
-            region = REGION_OPTIONS[user_input[CONF_REGION]]
-            api_level = int(user_input[CONF_API_LEVEL])
-
-            try:
-                session = async_get_clientsession(self.hass)
-                connection = AudiConnectAccount(
-                    session=session,
-                    username=reconfigure_entry.data[CONF_USERNAME],
-                    password=password,
-                    country=region,
-                    spin=spin,
-                    api_level=api_level,
-                )
-                if not await connection.try_login(False):
-                    errors["base"] = "invalid_credentials"
-                else:
-                    return self.async_update_reload_and_abort(
-                        reconfigure_entry,
-                        data_updates={
-                            CONF_PASSWORD: password,
-                            CONF_SPIN: spin,
-                            CONF_REGION: region,
-                            CONF_API_LEVEL: api_level,
-                        },
-                    )
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("Audi reconfigure flow failed")
-                errors["base"] = "unexpected"
+            return self.async_update_reload_and_abort(
+                reconfigure_entry,
+                data_updates={
+                    CONF_SPIN: user_input.get(CONF_SPIN),
+                    CONF_REGION: REGION_OPTIONS[user_input[CONF_REGION]],
+                    CONF_API_LEVEL: int(user_input[CONF_API_LEVEL]),
+                },
+            )
 
         current_region = reconfigure_entry.data.get(CONF_REGION, "DE")
         current_region_key = str(REGION_REVERSE.get(current_region, 1))
@@ -174,10 +220,6 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_PASSWORD,
-                        default=reconfigure_entry.data.get(CONF_PASSWORD, ""),
-                    ): str,
                     vol.Optional(
                         CONF_SPIN,
                         default=reconfigure_entry.data.get(CONF_SPIN, ""),
@@ -208,10 +250,6 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                 }
             ),
-            description_placeholders={
-                "username": reconfigure_entry.data[CONF_USERNAME],
-            },
-            errors=errors,
         )
 
     @staticmethod

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -32,6 +32,7 @@ CONF_SPIN = "spin"
 CONF_REGION = "region"
 CONF_FILTER_VINS = "filter_vins"
 CONF_REFRESH_AFTER_ACTION = "refresh_vehicle_data_after_action"
+CONF_REFRESH_TOKEN = "refresh_token"
 CONF_UPDATE_SLEEP = "update_sleep"
 
 REFRESH_VEHICLE_DATA_FAILED_EVENT = "refresh_failed"
@@ -77,6 +78,7 @@ __all__ = [
     "CONF_DURATION",
     "CONF_FILTER_VINS",
     "CONF_REFRESH_AFTER_ACTION",
+    "CONF_REFRESH_TOKEN",
     "CONF_UPDATE_SLEEP",
     "CONF_PASSWORD",
     "CONF_REGION",

--- a/custom_components/audiconnect/coordinator.py
+++ b/custom_components/audiconnect/coordinator.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .audi_account import AudiAccount
@@ -38,6 +39,10 @@ class AudiDataUpdateCoordinator(DataUpdateCoordinator[list[Any]]):
     async def _async_update_data(self) -> list[Any]:
         try:
             return await self.account.async_refresh_data()
+        except (ConfigEntryAuthFailed, ConfigEntryNotReady):
+            # Let Home Assistant handle reauth / retry-setup instead of masking
+            # these as a generic update failure.
+            raise
         except Exception as err:  # noqa: BLE001
             raise UpdateFailed(str(err)) from err
 

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -1,36 +1,41 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Invalid credentials",
-      "user_already_configured": "Account has already been configured"
+      "already_configured": "Account has already been configured",
+      "reauth_successful": "Re-authentication was successful",
+      "device_auth_failed": "Could not start device sign-in with Audi. Please try again later."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Invalid credentials",
-      "invalid_username": "Invalid username",
-      "unexpected": "Unexpected error communicating with Audi Connect server",
-      "user_already_configured": "Account has already been configured"
+      "authorization_pending": "Sign-in not detected yet. Approve the request in your browser, then press Submit.",
+      "device_auth_failed": "Device sign-in failed. Please start again."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Set your account options. On the next screen you will sign in with your Audi account in a browser.",
         "data": {
-          "password": "Password",
-          "username": "Username",
           "spin": "S-PIN",
           "region": "Region",
           "scan_interval": "Scan interval",
           "api_level": "API Level"
         },
-        "title": "Audi Connect Account Info",
         "data_description": {
-          "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models. Adjusting the API Level ensures that the system automatically applies the correct data structure for each specific vehicle. This can be changed later via the Reconfigure option."
+          "spin": "Optional S-PIN, required for vehicle actions such as lock/unlock and engine start.",
+          "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models. This can be changed later via the Reconfigure option."
         }
+      },
+      "device": {
+        "title": "Sign in to Audi",
+        "description": "Open the following link and sign in with your Audi account to authorise Home Assistant:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **Submit**."
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with Audi",
+        "description": "Your Audi authorisation has expired. Open the following link and sign in again:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **Submit**."
       },
       "reconfigure": {
         "title": "Update Audi Connect Configuration",
-        "description": "Update settings for account **{username}**.",
         "data": {
-          "password": "Password",
           "spin": "S-PIN",
           "region": "Region",
           "api_level": "API Level"
@@ -38,7 +43,7 @@
         "data_description": {
           "spin": "Optional S-PIN for vehicle actions such as lock/unlock.",
           "region": "The region associated with your Audi Connect account.",
-          "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models. Adjusting the API Level ensures that the system automatically applies the correct data structure for each specific vehicle."
+          "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models."
         }
       }
     }

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -1,36 +1,41 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Invalid credentials",
-      "user_already_configured": "Account has already been configured"
+      "already_configured": "Account has already been configured",
+      "reauth_successful": "Re-authentication was successful",
+      "device_auth_failed": "Could not start device sign-in with Audi. Please try again later."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Invalid credentials",
-      "invalid_username": "Invalid username",
-      "unexpected": "Unexpected error communicating with Audi Connect server",
-      "user_already_configured": "Account has already been configured"
+      "authorization_pending": "Sign-in not detected yet. Approve the request in your browser, then press Submit.",
+      "device_auth_failed": "Device sign-in failed. Please start again."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Set your account options. On the next screen you will sign in with your Audi account in a browser.",
         "data": {
-          "password": "Password",
-          "username": "Username",
           "spin": "S-PIN",
           "region": "Region",
           "scan_interval": "Scan interval",
           "api_level": "API Level"
         },
-        "title": "Audi Connect Account Info",
         "data_description": {
-          "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models. Adjusting the API Level ensures that the system automatically applies the correct data structure for each specific vehicle. This can be changed later via the Reconfigure option."
+          "spin": "Optional S-PIN, required for vehicle actions such as lock/unlock and engine start.",
+          "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models. This can be changed later via the Reconfigure option."
         }
+      },
+      "device": {
+        "title": "Sign in to Audi",
+        "description": "Open the following link and sign in with your Audi account to authorise Home Assistant:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **Submit**."
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with Audi",
+        "description": "Your Audi authorisation has expired. Open the following link and sign in again:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **Submit**."
       },
       "reconfigure": {
         "title": "Update Audi Connect Configuration",
-        "description": "Update settings for account **{username}**.",
         "data": {
-          "password": "Password",
           "spin": "S-PIN",
           "region": "Region",
           "api_level": "API Level"
@@ -38,7 +43,7 @@
         "data_description": {
           "spin": "Optional S-PIN for vehicle actions such as lock/unlock.",
           "region": "The region associated with your Audi Connect account.",
-          "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models. Adjusting the API Level ensures that the system automatically applies the correct data structure for each specific vehicle."
+          "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models."
         }
       }
     }


### PR DESCRIPTION
## What this fixes

Since early July 2026 login has failed with `KeyError('access_token')` (issues #772, #775, #756). The real failure is the final token exchange:

```
POST https://emea.bff.cariad.digital/auth/v1/idk/oidc/token  (grant_type=authorization_code)
-> 400 {"error":"invalid assertion headers"}
```

Audi/CARIAD now require a genuine Google Play Integrity attestation (an `X-Assertion` header) on the authorization-code token exchange. The current myAudi app carries a full Play Integrity stack for this (`technology.cariad.cat.playintegrity.*`, `IdentityKit$Error$PlayIntegrity`). That token cannot be produced off-device, so the username and password flow this integration used can no longer complete, and the stale `X-QMAuth` header it sent is rejected.

Switching to a hybrid OIDC flow (as the VW and Cupra connectors did) does not work for Audi: the Audi client is registered for the basic authorization-code flow only, and every `response_type` that returns a front-channel token is rejected with `invalid client` (verified live against `identity.vwgroup.io`).

## The approach

Use the OAuth Device Authorization Grant (RFC 8628) instead. The same CARIAD token endpoint accepts the `device_code` grant with no attestation header, and the refresh-token grant is un-attested too. This was verified end to end against a live account: the device flow yields a token, that token is accepted by the vehicle API (`GET /vehicle/v1/vehicles` returns the vehicle), and the refreshed token keeps working. It has also been tested in a running Home Assistant instance.

Sign-in becomes a one-time browser approval (the myAudi device-code page), after which the integration stores the IDK refresh token and refreshes headlessly, exactly as it did before.

## Changes

- `audi_services.py`: add `request_device_code`, `poll_device_token` and `login_with_refresh_token`; share the AZS and mbboauth token derivation via `_finalize_session`; drop the password and HTML-scrape flow and the stale `X-QMAuth` header; raise a typed auth error when a token is rejected.
- Account layer: token-based auth, persist rotated refresh tokens back to the config entry, and raise a dedicated auth error so Home Assistant starts reauth when the stored token expires.
- Config flow: device-code setup and reauth steps; reconfigure keeps region, S-PIN and API level.
- Migrate config entries v2 to v3 (removes stored credentials and prompts a one-time device-code sign-in).

## Breaking change

Existing entries migrate to v3 and must sign in again through the new device-code flow. The username and password are no longer used or stored.

## Notes

Fixes #772. Likely also resolves #775 and #756.

This was investigated and implemented with Claude Code, including live verification of the device-code flow and an adversarial review pass. Happy to adjust anything to fit the project's preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
