### PR TITLE
fix(i18n): add device-code steps to all shipped translations

### DIFF
--- a/custom_components/audiconnect/translations/de.json
+++ b/custom_components/audiconnect/translations/de.json
@@ -1,29 +1,49 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Ung\u00fcltige Anmeldeinformationen",
-      "user_already_configured": "Konto wurde bereits konfiguriert"
+      "already_configured": "Das Konto wurde bereits konfiguriert",
+      "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
+      "device_auth_failed": "Die Geräteanmeldung bei Audi konnte nicht gestartet werden. Bitte versuchen Sie es später erneut."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Ung\u00fcltige Anmeldeinformationen",
-      "invalid_username": "Ung\u00fcltiger Benutzername",
-      "unexpected": "Unerwarteter Fehler bei der Kommunikation mit dem Audi Connect Server",
-      "user_already_configured": "Konto wurde bereits konfiguriert"
+      "authorization_pending": "Anmeldung noch nicht erkannt. Bestätigen Sie die Anfrage in Ihrem Browser und klicken Sie dann auf Senden.",
+      "device_auth_failed": "Die Geräteanmeldung ist fehlgeschlagen. Bitte beginnen Sie erneut."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Legen Sie Ihre Kontooptionen fest. Im nächsten Schritt melden Sie sich in einem Browser mit Ihrem Audi-Konto an.",
         "data": {
-          "password": "Passwort",
-          "username": "Benutzername",
           "spin": "S-PIN",
           "region": "Region",
           "scan_interval": "Abfrageintervall",
           "api_level": "API-Level"
         },
-        "title": "Audi Connect Kontoinformationen",
         "data_description": {
-          "api_level": "Die Datenstruktur des API-Requests variiert je nach Audi-Modell. Neuere Fahrzeuge verwenden eine aktualisierte Struktur im Vergleich zu \u00e4lteren Modellen. Durch die Anpassung des API-Levels wird sichergestellt, dass das Fahrzeug die korrekte, fahrzeugspezifische Datenstruktur nutzt. Diese Einstellung kann sp\u00e4ter \u00fcber die Option \u201eNeu konfigurieren\u201c ge\u00e4ndert werden."
+          "spin": "Optionale S-PIN, erforderlich für Fahrzeugaktionen wie Ver-/Entriegeln und Motorstart.",
+          "api_level": "Bei Audi-Fahrzeugen variiert die Struktur der API-Anfragen je nach Modell. Neuere Fahrzeuge verwenden eine aktualisierte Datenstruktur als ältere Modelle. Dies kann später über die Option Neu konfigurieren geändert werden."
+        }
+      },
+      "device": {
+        "title": "Bei Audi anmelden",
+        "description": "Öffnen Sie den folgenden Link und melden Sie sich mit Ihrem Audi-Konto an, um Home Assistant zu autorisieren:\n\n[{verification_uri}]({verification_uri})\n\nFalls Sie nach einem Code gefragt werden, geben Sie ein: **{user_code}**\n\nSobald Sie die Anfrage bestätigt haben, klicken Sie auf **Senden**."
+      },
+      "reauth_confirm": {
+        "title": "Erneut bei Audi authentifizieren",
+        "description": "Ihre Audi-Autorisierung ist abgelaufen. Öffnen Sie den folgenden Link und melden Sie sich erneut an:\n\n[{verification_uri}]({verification_uri})\n\nFalls Sie nach einem Code gefragt werden, geben Sie ein: **{user_code}**\n\nSobald Sie die Anfrage bestätigt haben, klicken Sie auf **Senden**."
+      },
+      "reconfigure": {
+        "title": "Audi Connect-Konfiguration aktualisieren",
+        "data": {
+          "spin": "S-PIN",
+          "region": "Region",
+          "api_level": "API-Level"
+        },
+        "data_description": {
+          "spin": "Optionale S-PIN für Fahrzeugaktionen wie Ver-/Entriegeln.",
+          "region": "Die Ihrem Audi Connect-Konto zugeordnete Region.",
+          "api_level": "Bei Audi-Fahrzeugen variiert die Struktur der API-Anfragen je nach Modell. Neuere Fahrzeuge verwenden eine aktualisierte Datenstruktur als ältere Modelle."
         }
       }
     }
@@ -37,7 +57,7 @@
         },
         "title": "Audi Connect-Optionen",
         "data_description": {
-          "scan_initial": "F\u00fchren Sie sofort nach dem Start ein Cloud-Update durch.",
+          "scan_initial": "Führen Sie sofort nach dem Start ein Cloud-Update durch.",
           "scan_interval": "Minuten zwischen Cloud-Abfragen."
         }
       }
@@ -50,11 +70,11 @@
         "unlock": "Freischalten",
         "start_climatisation": "Klimatisierung starten (Legacy)",
         "stop_climatisation": "Schluss mit der Klimatisierung",
-        "start_charger": "Ladeger\u00e4t starten",
-        "start_timed_charger": "Starten Sie das zeitgesteuerte Ladeger\u00e4t",
-        "stop_charger": "Stoppen Sie das Ladeger\u00e4t",
-        "start_preheater": "Vorw\u00e4rmer starten",
-        "stop_preheater": "Stoppen Sie den Vorw\u00e4rmer",
+        "start_charger": "Ladegerät starten",
+        "start_timed_charger": "Starten Sie das zeitgesteuerte Ladegerät",
+        "stop_charger": "Stoppen Sie das Ladegerät",
+        "start_preheater": "Vorwärmer starten",
+        "stop_preheater": "Stoppen Sie den Vorwärmer",
         "start_window_heating": "Fensterheizung starten",
         "stop_window_heating": "Stoppen Sie die Fensterheizung",
         "is_moving": "In Bewegung"
@@ -74,22 +94,22 @@
     },
     "execute_vehicle_action": {
       "name": "Fahrzeugaktionen ausfuhren",
-      "description": "F\u00fchrt verschiedene Aktionen am Fahrzeug aus.",
+      "description": "Führt verschiedene Aktionen am Fahrzeug aus.",
       "fields": {
         "device_id": {
           "name": "Fahrzeug",
-          "description": "Das Audi-Fahrzeug, an dem die Aktion ausgef\u00fchrt werden soll."
+          "description": "Das Audi-Fahrzeug, an dem die Aktion ausgeführt werden soll."
         },
         "action": {
           "name": "Aktion",
-          "description": "Die spezifische Aktion, die am Fahrzeug ausgef\u00fchrt werden soll. Beachten Sie, dass die verf\u00fcgbaren Aktionen je nach Fahrzeug variieren k\u00f6nnen.",
+          "description": "Die spezifische Aktion, die am Fahrzeug ausgeführt werden soll. Beachten Sie, dass die verfügbaren Aktionen je nach Fahrzeug variieren können.",
           "example": "lock"
         }
       }
     },
     "start_climate_control": {
       "name": "Starten Sie die Klimatisierung",
-      "description": "Starten Sie die Klimaanlage mit Optionen f\u00fcr Temperatur, Glasfl\u00e4chenheizung und automatischen Sitzkomfort.",
+      "description": "Starten Sie die Klimaanlage mit Optionen für Temperatur, Glasflächenheizung und automatischen Sitzkomfort.",
       "fields": {
         "device_id": {
           "name": "Fahrzeug",
@@ -97,37 +117,37 @@
         },
         "temp_f": {
           "name": "Zieltemperatur (Fahrenheit)",
-          "description": "(Optional) Stellen Sie die Temperatur in \u00b0F ein. Standardm\u00e4\u00dfig 70 \u00b0F, sofern nicht angegeben. \u00dcberschreibt 'temp_c'."
+          "description": "(Optional) Stellen Sie die Temperatur in °F ein. Standardmäßig 70 °F, sofern nicht angegeben. Überschreibt 'temp_c'."
         },
         "temp_c": {
           "name": "Zieltemperatur (Celsius)",
-          "description": "(Optional) Stellen Sie die Temperatur in \u00b0C ein. Standardm\u00e4\u00dfig 21 \u00b0C, sofern nicht angegeben. Wird \u00fcberschrieben, wenn \u201etemp_f\u201c bereitgestellt wird."
+          "description": "(Optional) Stellen Sie die Temperatur in °C ein. Standardmäßig 21 °C, sofern nicht angegeben. Wird überschrieben, wenn „temp_f“ bereitgestellt wird."
         },
         "glass_heating": {
-          "name": "Glasfl\u00e4chenheizung",
-          "description": "(Optional) Aktivieren oder deaktivieren Sie die Glasfl\u00e4chenheizung."
+          "name": "Glasflächenheizung",
+          "description": "(Optional) Aktivieren oder deaktivieren Sie die Glasflächenheizung."
         },
         "seat_fl": {
           "name": "Automatischer Sitzkomfort: Vorne links",
-          "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort f\u00fcr den vorderen linken Sitz."
+          "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort für den vorderen linken Sitz."
         },
         "seat_fr": {
           "name": "Automatischer Sitzkomfort: Vorne rechts",
-          "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort f\u00fcr den Vordersitz rechts."
+          "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort für den Vordersitz rechts."
         },
         "seat_rl": {
           "name": "Automatischer Sitzkomfort: Hinten links",
-          "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort f\u00fcr den linken R\u00fccksitz."
+          "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort für den linken Rücksitz."
         },
         "seat_rr": {
           "name": "Automatischer Sitzkomfort: Hinten rechts",
-          "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort f\u00fcr den rechten R\u00fccksitz."
+          "description": "(Optional) Aktivieren oder deaktivieren Sie den automatischen Sitzkomfort für den rechten Rücksitz."
         }
       }
     },
     "refresh_cloud_data": {
       "name": "Cloud-Daten aktualisieren",
-      "description": "Ruft aktuelle Cloud-Daten ab, ohne eine Fahrzeugaktualisierung auszul\u00f6sen. Die Daten sind m\u00f6glicherweise veraltet, wenn das Fahrzeug nicht k\u00fcrzlich eingecheckt wurde."
+      "description": "Ruft aktuelle Cloud-Daten ab, ohne eine Fahrzeugaktualisierung auszulösen. Die Daten sind möglicherweise veraltet, wenn das Fahrzeug nicht kürzlich eingecheckt wurde."
     }
   }
 }

--- a/custom_components/audiconnect/translations/fi.json
+++ b/custom_components/audiconnect/translations/fi.json
@@ -1,29 +1,49 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Virheelliset tunnistetiedot",
-      "user_already_configured": "Tili on jo m\u00e4\u00e4ritetty"
+      "already_configured": "Tili on jo määritetty",
+      "reauth_successful": "Uudelleentodennus onnistui",
+      "device_auth_failed": "Laitekirjautumista Audiin ei voitu aloittaa. Yritä myöhemmin uudelleen."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Virheelliset tunnistetiedot",
-      "invalid_username": "Virheellinen k\u00e4ytt\u00e4j\u00e4tunnus",
-      "unexpected": "Odottamaton virhe yhdistett\u00e4ess\u00e4 Audi Connect -palveluun",
-      "user_already_configured": "Tili on jo m\u00e4\u00e4ritetty"
+      "authorization_pending": "Kirjautumista ei ole vielä havaittu. Hyväksy pyyntö selaimessasi ja paina sitten Lähetä.",
+      "device_auth_failed": "Laitekirjautuminen epäonnistui. Aloita uudelleen."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Määritä tilisi asetukset. Seuraavassa vaiheessa kirjaudut Audi-tilillesi selaimessa.",
         "data": {
-          "password": "Salasana",
-          "username": "K\u00e4ytt\u00e4j\u00e4tunnus",
           "spin": "S-PIN",
           "region": "Alue",
-          "scan_interval": "Skannausv\u00e4li",
+          "scan_interval": "Hakuväli",
           "api_level": "API-taso"
         },
-        "title": "Audi Connect -tilin tiedot",
         "data_description": {
-          "api_level": "Audi-ajoneuvoissa API-pyynn\u00f6n tietorakenne vaihtelee mallin mukaan. Uudemmat ajoneuvot k\u00e4ytt\u00e4v\u00e4t p\u00e4ivitetty\u00e4 tietorakennetta verrattuna vanhempiin malleihin. API-tason s\u00e4\u00e4t\u00e4minen varmistaa, ett\u00e4 j\u00e4rjestelm\u00e4 k\u00e4ytt\u00e4\u00e4 kussakin ajoneuvossa oikeaa tietorakennetta. T\u00e4t\u00e4 voi muuttaa my\u00f6hemmin Uudelleenm\u00e4\u00e4ritys-valinnan kautta."
+          "spin": "Valinnainen S-PIN, tarvitaan ajoneuvon toimintoihin, kuten lukitseminen/avaaminen ja moottorin käynnistys.",
+          "api_level": "Audi-ajoneuvoissa API-pyyntöjen rakenne vaihtelee mallin mukaan. Uudemmat ajoneuvot käyttävät päivitettyä tietorakennetta vanhempiin malleihin verrattuna. Tämän voi muuttaa myöhemmin Määritä uudelleen -valinnalla."
+        }
+      },
+      "device": {
+        "title": "Kirjaudu Audiin",
+        "description": "Avaa seuraava linkki ja kirjaudu Audi-tililläsi valtuuttaaksesi Home Assistantin:\n\n[{verification_uri}]({verification_uri})\n\nJos sinulta pyydetään koodia, syötä: **{user_code}**\n\nKun olet hyväksynyt pyynnön, paina **Lähetä**."
+      },
+      "reauth_confirm": {
+        "title": "Todenna uudelleen Audiin",
+        "description": "Audi-valtuutuksesi on vanhentunut. Avaa seuraava linkki ja kirjaudu uudelleen:\n\n[{verification_uri}]({verification_uri})\n\nJos sinulta pyydetään koodia, syötä: **{user_code}**\n\nKun olet hyväksynyt pyynnön, paina **Lähetä**."
+      },
+      "reconfigure": {
+        "title": "Päivitä Audi Connect -määritykset",
+        "data": {
+          "spin": "S-PIN",
+          "region": "Alue",
+          "api_level": "API-taso"
+        },
+        "data_description": {
+          "spin": "Valinnainen S-PIN ajoneuvon toimintoihin, kuten lukitseminen/avaaminen.",
+          "region": "Audi Connect -tiliisi liitetty alue.",
+          "api_level": "Audi-ajoneuvoissa API-pyyntöjen rakenne vaihtelee mallin mukaan. Uudemmat ajoneuvot käyttävät päivitettyä tietorakennetta vanhempiin malleihin verrattuna."
         }
       }
     }
@@ -32,13 +52,13 @@
     "step": {
       "init": {
         "data": {
-          "scan_initial": "P\u00e4ivit\u00e4 pilwest\u00e4 k\u00e4ynnistyksess\u00e4",
-          "scan_interval": "Aikav\u00e4li"
+          "scan_initial": "Päivitä pilwestä käynnistyksessä",
+          "scan_interval": "Aikaväli"
         },
         "title": "Audi Connect -asetukset",
         "data_description": {
-          "scan_initial": "P\u00e4ivit\u00e4 pilwest\u00e4 heti k\u00e4ynnistyksen yhteydess\u00e4.",
-          "scan_interval": "Minuutit pilvikyselyjen v\u00e4lill\u00e4."
+          "scan_initial": "Päivitä pilwestä heti käynnistyksen yhteydessä.",
+          "scan_interval": "Minuutit pilvikyselyjen välillä."
         }
       }
     }
@@ -48,26 +68,26 @@
       "options": {
         "lock": "Lukitse",
         "unlock": "Avaa lukitus",
-        "start_climatisation": "K\u00e4ynnist\u00e4 ilmastointi (perinteinen)",
-        "stop_climatisation": "Pys\u00e4yt\u00e4 ilmastointi",
-        "start_charger": "K\u00e4ynnist\u00e4 laturi",
+        "start_climatisation": "Käynnistä ilmastointi (perinteinen)",
+        "stop_climatisation": "Pysäytä ilmastointi",
+        "start_charger": "Käynnistä laturi",
         "start_timed_charger": "Aloita ajastettu lataus",
-        "stop_charger": "Pys\u00e4yt\u00e4 laturi",
-        "start_preheater": "K\u00e4ynnist\u00e4 lis\u00e4l\u00e4mmitin (perinteinen)",
-        "stop_preheater": "Pys\u00e4yt\u00e4 lis\u00e4l\u00e4mmitin",
-        "start_window_heating": "K\u00e4ynnist\u00e4 ikkunal\u00e4mmitys",
-        "stop_window_heating": "Pys\u00e4yt\u00e4 ikkunal\u00e4mmitys"
+        "stop_charger": "Pysäytä laturi",
+        "start_preheater": "Käynnistä lisälämmitin (perinteinen)",
+        "stop_preheater": "Pysäytä lisälämmitin",
+        "start_window_heating": "Käynnistä ikkunalämmitys",
+        "stop_window_heating": "Pysäytä ikkunalämmitys"
       }
     }
   },
   "services": {
     "refresh_vehicle_data": {
-      "name": "P\u00e4ivit\u00e4 ajoneuvon tiedot",
-      "description": "Pyyt\u00e4\u00e4 ajoneuvon tilan p\u00e4ivityst\u00e4 suoraan, pilwest\u00e4 p\u00e4ivityst\u00e4 odottamatta - toisin kuin normaali p\u00e4ivitys, joka hakee vain pilvitietoja.",
+      "name": "Päivitä ajoneuvon tiedot",
+      "description": "Pyytää ajoneuvon tilan päivitystä suoraan, pilwestä päivitystä odottamatta - toisin kuin normaali päivitys, joka hakee vain pilvitietoja.",
       "fields": {
         "device_id": {
           "name": "Ajoneuvo",
-          "description": "Audi-ajoneuvo, jonka tiedot p\u00e4ivitet\u00e4\u00e4n."
+          "description": "Audi-ajoneuvo, jonka tiedot päivitetään."
         }
       }
     },
@@ -81,64 +101,64 @@
         },
         "action": {
           "name": "Toiminto",
-          "description": "Ajoneuvolle suoritettava toiminto. Huomaa, ett\u00e4 saatavilla olevat toiminnot voivat vaihdella ajoneuvon mukaan.",
+          "description": "Ajoneuvolle suoritettava toiminto. Huomaa, että saatavilla olevat toiminnot voivat vaihdella ajoneuvon mukaan.",
           "example": "lukitse"
         }
       }
     },
     "start_climate_control": {
-      "name": "K\u00e4ynnist\u00e4 ilmastointi",
-      "description": "K\u00e4ynnist\u00e4 ilmastointi l\u00e4mp\u00f6tila-, ikkunal\u00e4mmitys- ja automaattisen istuinmukavuuden asetuksilla.",
+      "name": "Käynnistä ilmastointi",
+      "description": "Käynnistä ilmastointi lämpötila-, ikkunalämmitys- ja automaattisen istuinmukavuuden asetuksilla.",
       "fields": {
         "device_id": {
           "name": "Ajoneuvo",
-          "description": "Audi-ajoneuvo, jonka ilmastointi k\u00e4ynnistet\u00e4\u00e4n."
+          "description": "Audi-ajoneuvo, jonka ilmastointi käynnistetään."
         },
         "temp_f": {
-          "name": "Kohdel\u00e4mp\u00f6tila (Fahrenheit)",
-          "description": "(Valinnainen) N\u00e4yt\u00e4 l\u00e4mp\u00f6tila Fahrenheit-asteina. Oletusarvo on 70 \u00b0F, jos arvoa ei anneta. Ohittaa 'temp_c'-asetuksen."
+          "name": "Kohdelämpötila (Fahrenheit)",
+          "description": "(Valinnainen) Näytä lämpötila Fahrenheit-asteina. Oletusarvo on 70 °F, jos arvoa ei anneta. Ohittaa 'temp_c'-asetuksen."
         },
         "temp_c": {
-          "name": "Kohdel\u00e4mp\u00f6tila (Celsius)",
-          "description": "(Valinnainen) N\u00e4yt\u00e4 l\u00e4mp\u00f6tila Celsius-asteina. Oletusarvo on 21 \u00b0C, jos arvoa ei anneta. Ohitetaan, jos 'temp_f' on asetettu."
+          "name": "Kohdelämpötila (Celsius)",
+          "description": "(Valinnainen) Näytä lämpötila Celsius-asteina. Oletusarvo on 21 °C, jos arvoa ei anneta. Ohitetaan, jos 'temp_f' on asetettu."
         },
         "glass_heating": {
-          "name": "Ikkunan l\u00e4mmitys",
-          "description": "(Valinnainen) Ota ikkunan l\u00e4mmitys k\u00e4ytt\u00f6\u00f6n tai pois k\u00e4yt\u00f6st\u00e4."
+          "name": "Ikkunan lämmitys",
+          "description": "(Valinnainen) Ota ikkunan lämmitys käyttöön tai pois käytöstä."
         },
         "seat_fl": {
           "name": "Automaattinen istuimen mukavuustoiminto: vasen etuistuin",
-          "description": "(Valinnainen) Ota vasemman etuistuimen automaattinen istuimen mukavuustoiminto k\u00e4ytt\u00f6\u00f6n tai pois k\u00e4yt\u00f6st\u00e4."
+          "description": "(Valinnainen) Ota vasemman etuistuimen automaattinen istuimen mukavuustoiminto käyttöön tai pois käytöstä."
         },
         "seat_fr": {
           "name": "Automaattinen istuimen mukavuustoiminto: oikea etuistuin",
-          "description": "(Valinnainen) Ota oikean etuistuimen automaattinen istuimen mukavuustoiminto k\u00e4ytt\u00f6\u00f6n tai pois k\u00e4yt\u00f6st\u00e4."
+          "description": "(Valinnainen) Ota oikean etuistuimen automaattinen istuimen mukavuustoiminto käyttöön tai pois käytöstä."
         },
         "seat_rl": {
           "name": "Automaattinen istuimen mukavuustoiminto: vasen takaistuin",
-          "description": "(Valinnainen) Ota vasemman takaistuimen automaattinen istuimen mukavuustoiminto k\u00e4ytt\u00f6\u00f6n tai pois k\u00e4yt\u00f6st\u00e4."
+          "description": "(Valinnainen) Ota vasemman takaistuimen automaattinen istuimen mukavuustoiminto käyttöön tai pois käytöstä."
         },
         "seat_rr": {
           "name": "Automaattinen istuimen mukavuustoiminto: oikea takaistuin",
-          "description": "(Valinnainen) Ota oikean takaistuimen automaattinen istuimen mukavuustoiminto k\u00e4ytt\u00f6\u00f6n tai pois k\u00e4yt\u00f6st\u00e4."
+          "description": "(Valinnainen) Ota oikean takaistuimen automaattinen istuimen mukavuustoiminto käyttöön tai pois käytöstä."
         }
       }
     },
     "refresh_cloud_data": {
-      "name": "P\u00e4ivit\u00e4 pilvitiedot",
-      "description": "Hakee nykyiset pilvitiedot k\u00e4ynnist\u00e4m\u00e4tt\u00e4 ajoneuvon p\u00e4ivityst\u00e4. Tiedot voivat olla vanhentuneita, jos ajoneuvo ei ole \u00e4skettain ollut yhteydess\u00e4."
+      "name": "Päivitä pilvitiedot",
+      "description": "Hakee nykyiset pilvitiedot käynnistämättä ajoneuvon päivitystä. Tiedot voivat olla vanhentuneita, jos ajoneuvo ei ole äskettain ollut yhteydessä."
     },
     "start_auxiliary_heating": {
-      "name": "K\u00e4ynnist\u00e4 lis\u00e4l\u00e4mmitys",
-      "description": "K\u00e4ynnist\u00e4 ajoneuvon lis\u00e4l\u00e4mmitys, kestoasetuksen valinta.",
+      "name": "Käynnistä lisälämmitys",
+      "description": "Käynnistä ajoneuvon lisälämmitys, kestoasetuksen valinta.",
       "fields": {
         "device_id": {
           "name": "Ajoneuvo",
-          "description": "Audi-ajoneuvo, jonka lis\u00e4l\u00e4mmitys k\u00e4ynnistet\u00e4\u00e4n."
+          "description": "Audi-ajoneuvo, jonka lisälämmitys käynnistetään."
         },
         "duration": {
           "name": "Kesto",
-          "description": "Lis\u00e4l\u00e4mmittimen k\u00e4yntiaika minuutteina ennen sammuttamista. Oletusarvo on 20 minuuttia, jos arvoa ei anneta."
+          "description": "Lisälämmittimen käyntiaika minuutteina ennen sammuttamista. Oletusarvo on 20 minuuttia, jos arvoa ei anneta."
         }
       }
     }

--- a/custom_components/audiconnect/translations/fr.json
+++ b/custom_components/audiconnect/translations/fr.json
@@ -1,26 +1,50 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Informations d'identification invalides",
-      "user_already_configured": "Le compte a d\u00e9j\u00e0 \u00e9t\u00e9 configur\u00e9"
+      "already_configured": "Ce compte est déjà configuré",
+      "reauth_successful": "Réauthentification réussie",
+      "device_auth_failed": "Impossible de démarrer la connexion par code avec Audi. Veuillez réessayer plus tard."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Informations d'identification invalides",
-      "invalid_username": "Nom d'utilisateur invalide",
-      "unexpected": "Erreur inattendue lors de la communication avec le serveur Audi Connect",
-      "user_already_configured": "Le compte a d\u00e9j\u00e0 \u00e9t\u00e9 configur\u00e9"
+      "authorization_pending": "Connexion pas encore détectée. Approuvez la demande dans votre navigateur, puis appuyez sur Envoyer.",
+      "device_auth_failed": "La connexion par code a échoué. Veuillez recommencer."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Définissez les options de votre compte. À l'écran suivant, vous vous connecterez à votre compte Audi dans un navigateur.",
         "data": {
-          "password": "Mot de passe",
-          "username": "Nom d'utilisateur",
           "spin": "S-PIN",
-          "region": "R\u00e9gion",
-          "scan_interval": "Intervalle de scan"
+          "region": "Région",
+          "scan_interval": "Intervalle de scan",
+          "api_level": "Niveau d'API"
         },
-        "title": "Informations sur le compte Audi Connect"
+        "data_description": {
+          "spin": "S-PIN optionnel, requis pour les actions sur le véhicule telles que le verrouillage/déverrouillage et le démarrage du moteur.",
+          "api_level": "Sur les véhicules Audi, la structure des requêtes API varie selon le modèle. Les véhicules récents utilisent une structure plus moderne que les anciens. Modifiable ensuite via l'option Reconfigurer."
+        }
+      },
+      "device": {
+        "title": "Connexion à Audi",
+        "description": "Ouvrez le lien suivant et connectez-vous avec votre compte Audi pour autoriser Home Assistant :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, appuyez sur **Envoyer**."
+      },
+      "reauth_confirm": {
+        "title": "Réauthentification Audi",
+        "description": "Votre autorisation Audi a expiré. Ouvrez le lien suivant et reconnectez-vous :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, appuyez sur **Envoyer**."
+      },
+      "reconfigure": {
+        "title": "Mettre à jour la configuration Audi Connect",
+        "data": {
+          "spin": "S-PIN",
+          "region": "Région",
+          "api_level": "Niveau d'API"
+        },
+        "data_description": {
+          "spin": "S-PIN optionnel pour les actions sur le véhicule telles que le verrouillage/déverrouillage.",
+          "region": "La région associée à votre compte Audi Connect.",
+          "api_level": "Sur les véhicules Audi, la structure des requêtes API varie selon le modèle. Les véhicules récents utilisent une structure plus moderne que les anciens."
+        }
       }
     }
   },
@@ -28,13 +52,13 @@
     "step": {
       "init": {
         "data": {
-          "scan_initial": "Mise \u00e0 jour du cloud au d\u00e9marrage",
-          "scan_interval": "Intervalle de mises \u00e0 jour"
+          "scan_initial": "Mise à jour du cloud au démarrage",
+          "scan_interval": "Intervalle de mises à jour"
         },
         "title": "Options Audi Connect",
         "data_description": {
-          "scan_initial": "Effectuer une mise \u00e0 jour du cloud imm\u00e9diatement apr\u00e8s le d\u00e9marrage.",
-          "scan_interval": "Minutes entre les mises \u00e0 jour du cloud."
+          "scan_initial": "Effectuer une mise à jour du cloud immédiatement après le démarrage.",
+          "scan_interval": "Minutes entre les mises à jour du cloud."
         }
       }
     }
@@ -43,86 +67,86 @@
     "vehicle_actions": {
       "options": {
         "lock": "Verrouiller",
-        "unlock": "D\u00e9verrouiller",
-        "start_climatisation": "D\u00e9marrer climatisation (H\u00e9rit\u00e9)",
-        "stop_climatisation": "Arr\u00eater climatisation",
-        "start_charger": "D\u00e9marrer chargeur",
-        "start_timed_charger": "D\u00e9marrage chronom\u00e9tr\u00e9 du chargeur",
-        "stop_charger": "Arr\u00eater Chargeur",
-        "start_preheater": "D\u00e9marrer pr\u00e9chauffage",
-        "stop_preheater": "Arr\u00eater pr\u00e9chauffage",
-        "start_window_heating": "D\u00e9marrer chauffage des fen\u00eatres",
-        "stop_window_heating": "Arr\u00eater chauffage des fen\u00eatres"
+        "unlock": "Déverrouiller",
+        "start_climatisation": "Démarrer climatisation (Hérité)",
+        "stop_climatisation": "Arrêter climatisation",
+        "start_charger": "Démarrer chargeur",
+        "start_timed_charger": "Démarrage chronométré du chargeur",
+        "stop_charger": "Arrêter Chargeur",
+        "start_preheater": "Démarrer préchauffage",
+        "stop_preheater": "Arrêter préchauffage",
+        "start_window_heating": "Démarrer chauffage des fenêtres",
+        "stop_window_heating": "Arrêter chauffage des fenêtres"
       }
     }
   },
   "services": {
     "refresh_vehicle_data": {
-      "name": "Actualiser les donn\u00e9es du v\u00e9hicule",
-      "description": "Demande directement une mise \u00e0 jour de l'\u00e9tat du v\u00e9hicule, contrairement au m\u00e9canisme de mise \u00e0 jour normal qui r\u00e9cup\u00e8re uniquement les donn\u00e9es du cloud.",
+      "name": "Actualiser les données du véhicule",
+      "description": "Demande directement une mise à jour de l'état du véhicule, contrairement au mécanisme de mise à jour normal qui récupère uniquement les données du cloud.",
       "fields": {
         "device_id": {
-          "name": "V\u00e9hicule",
-          "description": "Le v\u00e9hicule Audi \u00e0 actualiser."
+          "name": "Véhicule",
+          "description": "Le véhicule Audi à actualiser."
         }
       }
     },
     "execute_vehicle_action": {
-      "name": "Ex\u00e9cuter l'action du v\u00e9hicule",
-      "description": "Effectue diverses actions sur le v\u00e9hicule.",
+      "name": "Exécuter l'action du véhicule",
+      "description": "Effectue diverses actions sur le véhicule.",
       "fields": {
         "device_id": {
-          "name": "V\u00e9hicule",
-          "description": "Le v\u00e9hicule Audi sur lequel effectuer l'action."
+          "name": "Véhicule",
+          "description": "Le véhicule Audi sur lequel effectuer l'action."
         },
         "action": {
           "name": "Action",
-          "description": "L'action sp\u00e9cifique \u00e0 effectuer sur le v\u00e9hicule. Noter que les actions disponibles peuvent varier en fonction du v\u00e9hicule.",
+          "description": "L'action spécifique à effectuer sur le véhicule. Noter que les actions disponibles peuvent varier en fonction du véhicule.",
           "example": "Verrouiller"
         }
       }
     },
     "start_climate_control": {
-      "name": "D\u00e9marrer la climatisation",
-      "description": "D\u00e9marrez la climatisation avec des options de temp\u00e9rature, de chauffage des vitres et de confort des si\u00e8ges auto.",
+      "name": "Démarrer la climatisation",
+      "description": "Démarrez la climatisation avec des options de température, de chauffage des vitres et de confort des sièges auto.",
       "fields": {
         "device_id": {
-          "name": "V\u00e9hicule",
-          "description": "Le v\u00e9hicule Audi sur lequel d\u00e9marrer la climatisation."
+          "name": "Véhicule",
+          "description": "Le véhicule Audi sur lequel démarrer la climatisation."
         },
         "temp_f": {
-          "name": "Temp\u00e9rature cible (Fahrenheit)",
-          "description": "(Optionel) R\u00e9gler la temp\u00e9rature en \u00b0F. La valeur par d\u00e9faut est 70\u00b0F si elle n'est pas fournie. Remplace 'temp_c'."
+          "name": "Température cible (Fahrenheit)",
+          "description": "(Optionel) Régler la température en °F. La valeur par défaut est 70°F si elle n'est pas fournie. Remplace 'temp_c'."
         },
         "temp_c": {
-          "name": "Temp\u00e9rature cible (Celsius)",
-          "description": "(Facultatif) R\u00e9gler la temp\u00e9rature en \u00b0C. La valeur par d\u00e9faut est 21\u00b0C si elle n'est pas fournie. Remplac\u00e9 si 'temp_f' est fourni."
+          "name": "Température cible (Celsius)",
+          "description": "(Facultatif) Régler la température en °C. La valeur par défaut est 21°C si elle n'est pas fournie. Remplacé si 'temp_f' est fourni."
         },
         "glass_heating": {
           "name": "Chauffage des vitres",
-          "description": "(Facultatif) Activer ou d\u00e9sactiver le chauffage des surfaces vitr\u00e9es."
+          "description": "(Facultatif) Activer ou désactiver le chauffage des surfaces vitrées."
         },
         "seat_fl": {
-          "name": "Confort du si\u00e8ge auto: Avant-Gauche",
-          "description": "(Facultatif) Activer ou d\u00e9sactiver Confort du si\u00e8ge auto pour le si\u00e8ge avant gauche."
+          "name": "Confort du siège auto: Avant-Gauche",
+          "description": "(Facultatif) Activer ou désactiver Confort du siège auto pour le siège avant gauche."
         },
         "seat_fr": {
-          "name": "Confort du si\u00e8ge auto: Avant-Droit",
-          "description": "(Facultatif) Activer ou d\u00e9sactiver Confort du si\u00e8ge auto pour le si\u00e8ge avant droit."
+          "name": "Confort du siège auto: Avant-Droit",
+          "description": "(Facultatif) Activer ou désactiver Confort du siège auto pour le siège avant droit."
         },
         "seat_rl": {
-          "name": "Confort du si\u00e8ge auto: Arri\u00e8re-Gauche",
-          "description": "(Facultatif) Activer ou d\u00e9sactiver Confort du si\u00e8ge auto pour le si\u00e8ge arri\u00e8re gauche."
+          "name": "Confort du siège auto: Arrière-Gauche",
+          "description": "(Facultatif) Activer ou désactiver Confort du siège auto pour le siège arrière gauche."
         },
         "seat_rr": {
-          "name": "Confort du si\u00e8ge auto: Arri\u00e8re-Droit",
-          "description": "(Facultatif) Activer ou d\u00e9sactiver Confort du si\u00e8ge auto pour le si\u00e8ge arri\u00e8re droit."
+          "name": "Confort du siège auto: Arrière-Droit",
+          "description": "(Facultatif) Activer ou désactiver Confort du siège auto pour le siège arrière droit."
         }
       }
     },
     "refresh_cloud_data": {
-      "name": "Actualiser les donn\u00e9es cloud",
-      "description": "R\u00e9cup\u00e8re les donn\u00e9es cloud actuelles sans d\u00e9clencher une actualisation du v\u00e9hicule. Les donn\u00e9es peuvent \u00eatre obsol\u00e8tes si le v\u00e9hicule n'a pas \u00e9t\u00e9 v\u00e9rifi\u00e9 r\u00e9cemment."
+      "name": "Actualiser les données cloud",
+      "description": "Récupère les données cloud actuelles sans déclencher une actualisation du véhicule. Les données peuvent être obsolètes si le véhicule n'a pas été vérifié récemment."
     }
   }
 }

--- a/custom_components/audiconnect/translations/fr.json
+++ b/custom_components/audiconnect/translations/fr.json
@@ -7,7 +7,7 @@
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Connexion pas encore détectée. Approuvez la demande dans votre navigateur, puis appuyez sur Envoyer.",
+      "authorization_pending": "Connexion pas encore détectée. Approuvez la demande dans votre navigateur, puis cliquez sur Valider.",
       "device_auth_failed": "La connexion par code a échoué. Veuillez recommencer."
     },
     "step": {
@@ -27,11 +27,11 @@
       },
       "device": {
         "title": "Connexion à Audi",
-        "description": "Ouvrez le lien suivant et connectez-vous avec votre compte Audi pour autoriser Home Assistant :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, appuyez sur **Envoyer**."
+        "description": "Ouvrez le lien suivant et connectez-vous avec votre compte Audi pour autoriser Home Assistant :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, cliquez sur **Valider**."
       },
       "reauth_confirm": {
         "title": "Réauthentification Audi",
-        "description": "Votre autorisation Audi a expiré. Ouvrez le lien suivant et reconnectez-vous :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, appuyez sur **Envoyer**."
+        "description": "Votre autorisation Audi a expiré. Ouvrez le lien suivant et reconnectez-vous :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, cliquez sur **Valider**."
       },
       "reconfigure": {
         "title": "Mettre à jour la configuration Audi Connect",

--- a/custom_components/audiconnect/translations/nb.json
+++ b/custom_components/audiconnect/translations/nb.json
@@ -1,26 +1,50 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Ugyldige innloggingsopplysninger",
-      "user_already_configured": "Kontoen er allerede konfigurert"
+      "already_configured": "Kontoen er allerede konfigurert",
+      "reauth_successful": "Ny autentisering var vellykket",
+      "device_auth_failed": "Kunne ikke starte enhetsinnlogging med Audi. Prøv igjen senere."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Ugyldige innloggingsopplysninger",
-      "invalid_username": "Ugyldig brukernavn",
-      "unexpected": "Uventet feil i kommunikasjonen med Audi Connect-serveren",
-      "user_already_configured": "Kontoen er allerede konfigurert"
+      "authorization_pending": "Innlogging er ennå ikke oppdaget. Godkjenn forespørselen i nettleseren din, og trykk deretter Send.",
+      "device_auth_failed": "Enhetsinnlogging mislyktes. Start på nytt."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Angi kontoalternativene dine. I neste steg logger du inn med Audi-kontoen din i en nettleser.",
         "data": {
-          "password": "Passord",
-          "username": "Brukernavn",
           "spin": "S-PIN",
           "region": "Region",
-          "scan_interval": "Skanneintervall"
+          "scan_interval": "Skanneintervall",
+          "api_level": "API-nivå"
         },
-        "title": "Audi Connect kontoinformasjon"
+        "data_description": {
+          "spin": "Valgfri S-PIN, kreves for kjøretøyhandlinger som låsing/opplåsing og motorstart.",
+          "api_level": "For Audi-kjøretøy varierer strukturen på API-forespørsler etter modell. Nyere kjøretøy bruker en oppdatert datastruktur sammenlignet med eldre modeller. Dette kan endres senere via alternativet Rekonfigurer."
+        }
+      },
+      "device": {
+        "title": "Logg inn på Audi",
+        "description": "Åpne følgende lenke og logg inn med Audi-kontoen din for å autorisere Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nHvis du blir bedt om en kode, skriv inn: **{user_code}**\n\nNår du har godkjent forespørselen, trykk **Send**."
+      },
+      "reauth_confirm": {
+        "title": "Autentiser på nytt med Audi",
+        "description": "Audi-autorisasjonen din har utløpt. Åpne følgende lenke og logg inn på nytt:\n\n[{verification_uri}]({verification_uri})\n\nHvis du blir bedt om en kode, skriv inn: **{user_code}**\n\nNår du har godkjent forespørselen, trykk **Send**."
+      },
+      "reconfigure": {
+        "title": "Oppdater Audi Connect-konfigurasjon",
+        "data": {
+          "spin": "S-PIN",
+          "region": "Region",
+          "api_level": "API-nivå"
+        },
+        "data_description": {
+          "spin": "Valgfri S-PIN for kjøretøyhandlinger som låsing/opplåsing.",
+          "region": "Regionen som er knyttet til Audi Connect-kontoen din.",
+          "api_level": "For Audi-kjøretøy varierer strukturen på API-forespørsler etter modell. Nyere kjøretøy bruker en oppdatert datastruktur sammenlignet med eldre modeller."
+        }
       }
     }
   },

--- a/custom_components/audiconnect/translations/nl.json
+++ b/custom_components/audiconnect/translations/nl.json
@@ -1,26 +1,50 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Ongeldige gebruikersgegevens",
-      "user_already_configured": "Account is al geconfigureerd"
+      "already_configured": "Dit account is al geconfigureerd",
+      "reauth_successful": "Herauthenticatie is geslaagd",
+      "device_auth_failed": "Kan de apparaataanmelding bij Audi niet starten. Probeer het later opnieuw."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Ongeldige gebruikersgegevens",
-      "invalid_username": "Ongeldige gebruikersnaam",
-      "unexpected": "Onverwachte fout bij communicatie met de Audi Connect server",
-      "user_already_configured": "Account is al geconfigureerd"
+      "authorization_pending": "Aanmelding nog niet gedetecteerd. Keur het verzoek goed in uw browser en klik daarna op Verzenden.",
+      "device_auth_failed": "Apparaataanmelding mislukt. Begin opnieuw."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Stel uw accountopties in. In de volgende stap meldt u zich in een browser aan met uw Audi-account.",
         "data": {
-          "password": "Wachtwoord",
-          "username": "Gebruikersnaam",
           "spin": "S-PIN",
           "region": "Regio",
-          "scan_interval": "Update interval"
+          "scan_interval": "Scaninterval",
+          "api_level": "API-niveau"
         },
-        "title": "Audi Connect accountgegevens"
+        "data_description": {
+          "spin": "Optionele S-PIN, vereist voor voertuigacties zoals vergrendelen/ontgrendelen en motorstart.",
+          "api_level": "Bij Audi-voertuigen verschilt de structuur van API-verzoeken per model. Nieuwere voertuigen gebruiken een bijgewerkte datastructuur ten opzichte van oudere modellen. Dit kan later worden gewijzigd via de optie Herconfigureren."
+        }
+      },
+      "device": {
+        "title": "Aanmelden bij Audi",
+        "description": "Open de volgende link en meld u aan met uw Audi-account om Home Assistant te autoriseren:\n\n[{verification_uri}]({verification_uri})\n\nAls om een code wordt gevraagd, voer in: **{user_code}**\n\nZodra u het verzoek hebt goedgekeurd, klikt u op **Verzenden**."
+      },
+      "reauth_confirm": {
+        "title": "Opnieuw authenticeren bij Audi",
+        "description": "Uw Audi-autorisatie is verlopen. Open de volgende link en meld u opnieuw aan:\n\n[{verification_uri}]({verification_uri})\n\nAls om een code wordt gevraagd, voer in: **{user_code}**\n\nZodra u het verzoek hebt goedgekeurd, klikt u op **Verzenden**."
+      },
+      "reconfigure": {
+        "title": "Audi Connect-configuratie bijwerken",
+        "data": {
+          "spin": "S-PIN",
+          "region": "Regio",
+          "api_level": "API-niveau"
+        },
+        "data_description": {
+          "spin": "Optionele S-PIN voor voertuigacties zoals vergrendelen/ontgrendelen.",
+          "region": "De regio die aan uw Audi Connect-account is gekoppeld.",
+          "api_level": "Bij Audi-voertuigen verschilt de structuur van API-verzoeken per model. Nieuwere voertuigen gebruiken een bijgewerkte datastructuur ten opzichte van oudere modellen."
+        }
       }
     }
   },

--- a/custom_components/audiconnect/translations/pt-BR.json
+++ b/custom_components/audiconnect/translations/pt-BR.json
@@ -1,26 +1,50 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Credenciais inválidas",
-      "user_already_configured": "A conta já foi configurada"
+      "already_configured": "A conta já foi configurada",
+      "reauth_successful": "A reautenticação foi bem-sucedida",
+      "device_auth_failed": "Não foi possível iniciar o login do dispositivo com a Audi. Tente novamente mais tarde."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Credenciais inválidas",
-      "invalid_username": "Nome de usuário inválido",
-      "unexpected": "Erro inesperado na comunicação com o servidor Audi Connect",
-      "user_already_configured": "A conta já foi configurada"
+      "authorization_pending": "Login ainda não detectado. Aprove a solicitação no seu navegador e depois clique em Enviar.",
+      "device_auth_failed": "O login do dispositivo falhou. Comece novamente."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Defina as opções da sua conta. Na próxima etapa, você fará login com a sua conta Audi em um navegador.",
         "data": {
-          "password": "Senha",
-          "username": "Nome de usuário",
           "spin": "S-PIN",
           "region": "Região",
-          "scan_interval": "Intervalo de escaneamento"
+          "scan_interval": "Intervalo de varredura",
+          "api_level": "Nível de API"
         },
-        "title": "Informações da conta Audi Connect "
+        "data_description": {
+          "spin": "S-PIN opcional, necessário para ações do veículo como travar/destravar e partida do motor.",
+          "api_level": "Nos veículos Audi, a estrutura das solicitações de API varia conforme o modelo. Veículos mais novos usam uma estrutura de dados atualizada em comparação com modelos mais antigos. Isso pode ser alterado depois pela opção Reconfigurar."
+        }
+      },
+      "device": {
+        "title": "Fazer login na Audi",
+        "description": "Abra o link a seguir e faça login com a sua conta Audi para autorizar o Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nSe um código for solicitado, digite: **{user_code}**\n\nApós aprovar a solicitação, clique em **Enviar**."
+      },
+      "reauth_confirm": {
+        "title": "Reautenticar com a Audi",
+        "description": "A sua autorização Audi expirou. Abra o link a seguir e faça login novamente:\n\n[{verification_uri}]({verification_uri})\n\nSe um código for solicitado, digite: **{user_code}**\n\nApós aprovar a solicitação, clique em **Enviar**."
+      },
+      "reconfigure": {
+        "title": "Atualizar a configuração do Audi Connect",
+        "data": {
+          "spin": "S-PIN",
+          "region": "Região",
+          "api_level": "Nível de API"
+        },
+        "data_description": {
+          "spin": "S-PIN opcional para ações do veículo como travar/destravar.",
+          "region": "A região associada à sua conta Audi Connect.",
+          "api_level": "Nos veículos Audi, a estrutura das solicitações de API varia conforme o modelo. Veículos mais novos usam uma estrutura de dados atualizada em comparação com modelos mais antigos."
+        }
       }
     }
   },

--- a/custom_components/audiconnect/translations/pt.json
+++ b/custom_components/audiconnect/translations/pt.json
@@ -1,26 +1,50 @@
 {
   "config": {
     "abort": {
-      "invalid_credentials": "Credenciais inválidas",
-      "user_already_configured": "A conta já foi configurada"
+      "already_configured": "A conta já foi configurada",
+      "reauth_successful": "A reautenticação foi bem-sucedida",
+      "device_auth_failed": "Não foi possível iniciar o início de sessão do dispositivo com a Audi. Tente novamente mais tarde."
     },
     "create_entry": {},
     "error": {
-      "invalid_credentials": "Credenciais inválidas",
-      "invalid_username": "Nome de utilizador inválido",
-      "unexpected": "Erro inesperado na comunicação com o servidor Audi Connect",
-      "user_already_configured": "A conta já foi configurada"
+      "authorization_pending": "Início de sessão ainda não detetado. Aprove o pedido no seu navegador e depois prima Enviar.",
+      "device_auth_failed": "O início de sessão do dispositivo falhou. Comece novamente."
     },
     "step": {
       "user": {
+        "title": "Audi Connect",
+        "description": "Defina as opções da sua conta. No passo seguinte, iniciará sessão com a sua conta Audi num navegador.",
         "data": {
-          "password": "Senha",
-          "username": "Nome de utilizador",
           "spin": "S-PIN",
           "region": "Região",
-          "scan_interval": "Intervalo de pesquisa"
+          "scan_interval": "Intervalo de análise",
+          "api_level": "Nível de API"
         },
-        "title": "Informações da conta Audi Connect "
+        "data_description": {
+          "spin": "S-PIN opcional, necessário para ações do veículo como bloquear/desbloquear e arranque do motor.",
+          "api_level": "Nos veículos Audi, a estrutura dos pedidos de API varia consoante o modelo. Os veículos mais recentes usam uma estrutura de dados atualizada em comparação com os modelos mais antigos. Isto pode ser alterado posteriormente através da opção Reconfigurar."
+        }
+      },
+      "device": {
+        "title": "Iniciar sessão na Audi",
+        "description": "Abra a ligação seguinte e inicie sessão com a sua conta Audi para autorizar o Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nSe lhe for pedido um código, introduza: **{user_code}**\n\nApós aprovar o pedido, prima **Enviar**."
+      },
+      "reauth_confirm": {
+        "title": "Reautenticar com a Audi",
+        "description": "A sua autorização Audi expirou. Abra a ligação seguinte e inicie sessão novamente:\n\n[{verification_uri}]({verification_uri})\n\nSe lhe for pedido um código, introduza: **{user_code}**\n\nApós aprovar o pedido, prima **Enviar**."
+      },
+      "reconfigure": {
+        "title": "Atualizar a configuração do Audi Connect",
+        "data": {
+          "spin": "S-PIN",
+          "region": "Região",
+          "api_level": "Nível de API"
+        },
+        "data_description": {
+          "spin": "S-PIN opcional para ações do veículo como bloquear/desbloquear.",
+          "region": "A região associada à sua conta Audi Connect.",
+          "api_level": "Nos veículos Audi, a estrutura dos pedidos de API varia consoante o modelo. Os veículos mais recentes usam uma estrutura de dados atualizada em comparação com os modelos mais antigos."
+        }
       }
     }
   },


### PR DESCRIPTION
Expands the earlier French-only fix to **all seven shipped languages**: `de`, `fi`, `fr`, `nb`, `nl`, `pt`, `pt-BR`.

## The problem (blocks setup, not just cosmetic)

The device-code flow updated `strings.json` and `en.json`, but the seven other language files still only had the old `user` step. **Home Assistant does not fall back to English for missing keys in custom-integration translations**, so with the UI in any of these languages the device step renders with an **empty body** — no verification URL, no user code, just a title and a Submit button. There is no way to approve a code you cannot see, so setup is impossible unless the user switches the whole UI to English. The same gap hits `reauth_confirm`, so those users would also be stuck when a token later expires.

The stale files were additionally wrong: they still labelled the removed `username`/`password` fields.

## What this does

For each of the seven languages:
- adds the `device`, `reauth_confirm` and `reconfigure` steps
- adds the new `abort` / `error` keys (`device_auth_failed`, `authorization_pending`, `reauth_successful`, `already_configured`)
- removes the obsolete `username` / `password` labels, adds `api_level`
- renders the verification URI as a clickable markdown link `[{verification_uri}]({verification_uri})` rather than bare text (worth mirroring in `en.json` too)

Placeholders (`{verification_uri}`, `{user_code}`) and JSON validity were verified programmatically for every file; existing `options` / `selector` / `services` sections are untouched.

## Honesty note

`fr` is native. The other six were translated carefully but not by a native speaker each — the strings are short and standard UI language, but **corrections from native speakers are very welcome** and easy to fold in. Shipping imperfect-but-complete translations still beats a blank screen.

---

**Depends on #777** — it removes the `username`/`password` fields these files no longer label, so merge this *after* #777, not before.
