### PR TITLE
fix: treat 502 on the status report as transient (debug, not error)

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -766,6 +766,15 @@ class AudiConnectVehicle:
         except ClientResponseError as resp_exception:
             if resp_exception.status in (403, 404):
                 self.support_status_report = False
+            elif resp_exception.status == 502:
+                # Transient CARIAD gateway error; the cached state is kept and the
+                # next poll normally recovers. Logged at debug like the other
+                # endpoints, not as an error, to avoid noise.
+                _LOGGER.debug(
+                    "Received status 502 while obtaining the vehicle status report "
+                    "of %s. This is typically transient and may resolve on its own.",
+                    self._vehicle.vin,
+                )
             else:
                 self.log_exception_once(
                     resp_exception,


### PR DESCRIPTION
Follow-up to #777, targeting `beta` as @coreywillwhat invited.

## What

`update_vehicle_statusreport` is the only endpoint handler **without** a `502` branch. A transient CARIAD gateway 502 on `selectivestatus` therefore surfaces as a full `ERROR` with traceback:

```
Unable to obtain the vehicle status report of …: 502, message='Bad Gateway',
url='…/vehicle/v1/vehicles/…/selectivestatus?jobs=…'
```

The sibling handlers (`update_vehicle_position`, charger, climater, timer, …) already treat 502 as transient and log it at **debug** ("typically transient and may resolve on its own"). This aligns the status report with that established pattern — 9 lines, one `elif status == 502` branch.

## Why it's safe

Purely log-level; no behaviour change. The cached state is kept and the next poll normally recovers, so nothing is lost — the 502 is a VW-side gateway hiccup, not a client error. Observed as a single occurrence in a live EMEA setup (Audi A3 Sportback e-tron).

No functional path touched; the 403/404 → `support_status_report = False` and the generic fallback are unchanged.