### PR TITLE
fix: keep the IDK session alive when mbboauth returns no refresh_token

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -1055,51 +1055,57 @@ class AudiService:
     # TR/2021-12-01: Refresh token before it expires
     # returns True when refresh was required and successful, otherwise False
     async def refresh_token_if_necessary(self, elapsed_sec: int) -> bool:
-        if self.mbboauthToken is None:
+        # The IDK bearer token drives the CARIAD BFF session and carries its own
+        # refresh token, independent of the mbboauth token. Base the timing on it
+        # and always refresh it: a login whose mbboauth response carried no
+        # refresh_token (see _finalize_session) must still keep the IDK session —
+        # and therefore every entity — alive past the ~1h access-token lifetime.
+        if self._bearer_token_json is None:
             return False
-        if "refresh_token" not in self.mbboauthToken:
+        if "refresh_token" not in self._bearer_token_json:
             return False
-        if "expires_in" not in self.mbboauthToken:
+        if "expires_in" not in self._bearer_token_json:
             return False
 
-        if (elapsed_sec + 5 * 60) < self.mbboauthToken["expires_in"]:
+        if (elapsed_sec + 5 * 60) < self._bearer_token_json["expires_in"]:
             # refresh not needed now
             return False
 
         try:
-            headers = {
-                "Accept": "application/json",
-                "Accept-Charset": "utf-8",
-                "User-Agent": AudiAPI.HDR_USER_AGENT,
-                "Content-Type": "application/x-www-form-urlencoded",
-                "X-Client-ID": self.xclientId,
-            }
-            mbboauth_refresh_data = {
-                "grant_type": "refresh_token",
-                "token": self.mbboauthToken["refresh_token"],
-                "scope": "sc2:fal",
-                # "vin": vin,  << App uses a dedicated VIN here, but it works without, don't know
-            }
-            encoded_mbboauth_refresh_data = urlencode(
-                mbboauth_refresh_data, encoding="utf-8"
-            ).replace("+", "%20")
-            mbboauth_refresh_rsp, mbboauth_refresh_rsptxt = await self._api.request(
-                "POST",
-                self.mbbOAuthBaseURL + "/mobile/oauth2/v1/token",
-                encoded_mbboauth_refresh_data,
-                headers=headers,
-                allow_redirects=False,
-                rsp_wtxt=True,
-            )
+            # mbboauth refresh — only when a refresh_token is available. The auth
+            # response no longer always includes one; when it doesn't, vwToken
+            # keeps its current value instead of blocking the IDK refresh below.
+            if self.mbboauthToken and "refresh_token" in self.mbboauthToken:
+                headers = {
+                    "Accept": "application/json",
+                    "Accept-Charset": "utf-8",
+                    "User-Agent": AudiAPI.HDR_USER_AGENT,
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "X-Client-ID": self.xclientId,
+                }
+                mbboauth_refresh_data = {
+                    "grant_type": "refresh_token",
+                    "token": self.mbboauthToken["refresh_token"],
+                    "scope": "sc2:fal",
+                }
+                encoded_mbboauth_refresh_data = urlencode(
+                    mbboauth_refresh_data, encoding="utf-8"
+                ).replace("+", "%20")
+                mbboauth_refresh_rsp, mbboauth_refresh_rsptxt = await self._api.request(
+                    "POST",
+                    self.mbbOAuthBaseURL + "/mobile/oauth2/v1/token",
+                    encoded_mbboauth_refresh_data,
+                    headers=headers,
+                    allow_redirects=False,
+                    rsp_wtxt=True,
+                )
+                # this code is the old "vwToken"
+                self.vwToken = json.loads(mbboauth_refresh_rsptxt)
+                # If a new refresh_token is provided, save it for further refreshes
+                if "refresh_token" in self.vwToken:
+                    self.mbboauthToken["refresh_token"] = self.vwToken["refresh_token"]
 
-            # this code is the old "vwToken"
-            self.vwToken = json.loads(mbboauth_refresh_rsptxt)
-
-            # TR/2022-02-10: If a new refresh_token is provided, save it for further refreshes
-            if "refresh_token" in self.vwToken:
-                self.mbboauthToken["refresh_token"] = self.vwToken["refresh_token"]
-
-            # hdr
+            # IDK refresh — always, using the IDK token's own refresh token.
             headers = {
                 "Accept": "application/json",
                 "Accept-Charset": "utf-8",


### PR DESCRIPTION
Follow-up on `beta` (device-code migration). This is the more delicate of the two — a core-auth change — so I've kept it isolated and flagged the testing status below.

## The bug

`refresh_token_if_necessary` refreshes **two independent tokens**:
- the **mbboauth** token → legacy `fs-car` endpoints (trip data, climater, charger…)
- the **IDK bearer** token → the CARIAD BFF endpoints, i.e. **every entity's data**

Both refreshes sat behind guards that bail when the *mbboauth* token has no `refresh_token`:
```python
if "refresh_token" not in self.mbboauthToken:
    return False
```
But `_finalize_session` explicitly handles the now-common case where the mbboauth auth response carries **no** refresh_token (its own comment: *"The MBB OAuth auth response no longer always includes a refresh_token"*). For those sessions the guard is always true, so the IDK bearer token — nested in the same method — is **never refreshed**. It expires ~1h after login, every BFF call then 401s, and nothing re-logs-in (only 403/404 flip support flags, not 401). Result: **all entities go `unavailable` ~1h after setup until HA is restarted or the user reauths.**

## The fix

Decouple the two refreshes:
- Base the timing on the **IDK bearer token's own `expires_in`** (always present) and **always** refresh it + re-derive the AZS token.
- Run the mbboauth refresh **only when** an mbboauth `refresh_token` is available.

For accounts whose mbboauth token *does* carry a refresh_token, behaviour is unchanged (both still refresh). Token-rotation persistence is untouched: `update()` → `_sync_refresh_token()` reads `current_refresh_token()`, which already tracks the IDK bearer token.

## Testing status (please read)

Logic verified by reading the full path (guards, timing, persistence wiring, `update()` caller) and the module imports cleanly. It is **not** runtime-tested across the ~1h expiry boundary, because that needs a session whose mbboauth response lacks a refresh_token — my own account gets one, so I can't reproduce the failing case locally. Targeting `beta` precisely so it can be confirmed in the pre-release. Happy to adjust.