### PR TITLE
fix: empty reconfigure dialog after updating from 2.2.0, missing reconfigure_successful text

### DIFF
--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -227,6 +227,11 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure",
+            # 2.2.0 interpolated {username} into the reconfigure description.
+            # A browser session from before the update still has that string
+            # cached, and rendering it without the value fails hard (formatjs
+            # MISSING_VALUE), leaving an empty dialog. Keep providing it.
+            description_placeholders={"username": reconfigure_entry.title},
             data_schema=vol.Schema(
                 {
                     vol.Optional(

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "Account has already been configured",
       "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful",
       "device_auth_failed": "Could not start device sign-in with Audi. Please try again later."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Sign-in not detected yet. Approve the request in your browser, then press Submit.",
+      "authorization_pending": "Sign-in not detected yet. Approve the request in your browser, then press OK.",
       "device_auth_failed": "Device sign-in failed. Please start again."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Sign in to Audi",
-        "description": "Open the following link and sign in with your Audi account to authorise Home Assistant:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **Submit**."
+        "description": "Open the following link and sign in with your Audi account to authorise Home Assistant:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **OK**."
       },
       "reauth_confirm": {
         "title": "Re-authenticate with Audi",
-        "description": "Your Audi authorisation has expired. Open the following link and sign in again:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **Submit**."
+        "description": "Your Audi authorisation has expired. Open the following link and sign in again:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **OK**."
       },
       "reconfigure": {
         "title": "Update Audi Connect Configuration",

--- a/custom_components/audiconnect/translations/de.json
+++ b/custom_components/audiconnect/translations/de.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "Das Konto wurde bereits konfiguriert",
       "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
+      "reconfigure_successful": "Die Neukonfiguration war erfolgreich",
       "device_auth_failed": "Die Geräteanmeldung bei Audi konnte nicht gestartet werden. Bitte versuchen Sie es später erneut."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Anmeldung noch nicht erkannt. Bestätigen Sie die Anfrage in Ihrem Browser und klicken Sie dann auf Senden.",
+      "authorization_pending": "Anmeldung noch nicht erkannt. Bestätigen Sie die Anfrage in Ihrem Browser und klicken Sie dann auf OK.",
       "device_auth_failed": "Die Geräteanmeldung ist fehlgeschlagen. Bitte beginnen Sie erneut."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Bei Audi anmelden",
-        "description": "Öffnen Sie den folgenden Link und melden Sie sich mit Ihrem Audi-Konto an, um Home Assistant zu autorisieren:\n\n[{verification_uri}]({verification_uri})\n\nFalls Sie nach einem Code gefragt werden, geben Sie ein: **{user_code}**\n\nSobald Sie die Anfrage bestätigt haben, klicken Sie auf **Senden**."
+        "description": "Öffnen Sie den folgenden Link und melden Sie sich mit Ihrem Audi-Konto an, um Home Assistant zu autorisieren:\n\n[{verification_uri}]({verification_uri})\n\nFalls Sie nach einem Code gefragt werden, geben Sie ein: **{user_code}**\n\nSobald Sie die Anfrage bestätigt haben, klicken Sie auf **OK**."
       },
       "reauth_confirm": {
         "title": "Erneut bei Audi authentifizieren",
-        "description": "Ihre Audi-Autorisierung ist abgelaufen. Öffnen Sie den folgenden Link und melden Sie sich erneut an:\n\n[{verification_uri}]({verification_uri})\n\nFalls Sie nach einem Code gefragt werden, geben Sie ein: **{user_code}**\n\nSobald Sie die Anfrage bestätigt haben, klicken Sie auf **Senden**."
+        "description": "Ihre Audi-Autorisierung ist abgelaufen. Öffnen Sie den folgenden Link und melden Sie sich erneut an:\n\n[{verification_uri}]({verification_uri})\n\nFalls Sie nach einem Code gefragt werden, geben Sie ein: **{user_code}**\n\nSobald Sie die Anfrage bestätigt haben, klicken Sie auf **OK**."
       },
       "reconfigure": {
         "title": "Audi Connect-Konfiguration aktualisieren",

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "Account has already been configured",
       "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful",
       "device_auth_failed": "Could not start device sign-in with Audi. Please try again later."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Sign-in not detected yet. Approve the request in your browser, then press Submit.",
+      "authorization_pending": "Sign-in not detected yet. Approve the request in your browser, then press OK.",
       "device_auth_failed": "Device sign-in failed. Please start again."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Sign in to Audi",
-        "description": "Open the following link and sign in with your Audi account to authorise Home Assistant:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **Submit**."
+        "description": "Open the following link and sign in with your Audi account to authorise Home Assistant:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **OK**."
       },
       "reauth_confirm": {
         "title": "Re-authenticate with Audi",
-        "description": "Your Audi authorisation has expired. Open the following link and sign in again:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **Submit**."
+        "description": "Your Audi authorisation has expired. Open the following link and sign in again:\n\n{verification_uri}\n\nIf you are asked for a code, enter: **{user_code}**\n\nOnce you have approved it, press **OK**."
       },
       "reconfigure": {
         "title": "Update Audi Connect Configuration",

--- a/custom_components/audiconnect/translations/fi.json
+++ b/custom_components/audiconnect/translations/fi.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "Tili on jo määritetty",
       "reauth_successful": "Uudelleentodennus onnistui",
+      "reconfigure_successful": "Uudelleenmääritys onnistui",
       "device_auth_failed": "Laitekirjautumista Audiin ei voitu aloittaa. Yritä myöhemmin uudelleen."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Kirjautumista ei ole vielä havaittu. Hyväksy pyyntö selaimessasi ja paina sitten Lähetä.",
+      "authorization_pending": "Kirjautumista ei ole vielä havaittu. Hyväksy pyyntö selaimessasi ja paina sitten OK.",
       "device_auth_failed": "Laitekirjautuminen epäonnistui. Aloita uudelleen."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Kirjaudu Audiin",
-        "description": "Avaa seuraava linkki ja kirjaudu Audi-tililläsi valtuuttaaksesi Home Assistantin:\n\n[{verification_uri}]({verification_uri})\n\nJos sinulta pyydetään koodia, syötä: **{user_code}**\n\nKun olet hyväksynyt pyynnön, paina **Lähetä**."
+        "description": "Avaa seuraava linkki ja kirjaudu Audi-tililläsi valtuuttaaksesi Home Assistantin:\n\n[{verification_uri}]({verification_uri})\n\nJos sinulta pyydetään koodia, syötä: **{user_code}**\n\nKun olet hyväksynyt pyynnön, paina **OK**."
       },
       "reauth_confirm": {
         "title": "Todenna uudelleen Audiin",
-        "description": "Audi-valtuutuksesi on vanhentunut. Avaa seuraava linkki ja kirjaudu uudelleen:\n\n[{verification_uri}]({verification_uri})\n\nJos sinulta pyydetään koodia, syötä: **{user_code}**\n\nKun olet hyväksynyt pyynnön, paina **Lähetä**."
+        "description": "Audi-valtuutuksesi on vanhentunut. Avaa seuraava linkki ja kirjaudu uudelleen:\n\n[{verification_uri}]({verification_uri})\n\nJos sinulta pyydetään koodia, syötä: **{user_code}**\n\nKun olet hyväksynyt pyynnön, paina **OK**."
       },
       "reconfigure": {
         "title": "Päivitä Audi Connect -määritykset",

--- a/custom_components/audiconnect/translations/fr.json
+++ b/custom_components/audiconnect/translations/fr.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "Ce compte est déjà configuré",
       "reauth_successful": "Réauthentification réussie",
+      "reconfigure_successful": "Reconfiguration réussie",
       "device_auth_failed": "Impossible de démarrer la connexion par code avec Audi. Veuillez réessayer plus tard."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Connexion pas encore détectée. Approuvez la demande dans votre navigateur, puis cliquez sur Valider.",
+      "authorization_pending": "Connexion pas encore détectée. Approuvez la demande dans votre navigateur, puis cliquez sur OK.",
       "device_auth_failed": "La connexion par code a échoué. Veuillez recommencer."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Connexion à Audi",
-        "description": "Ouvrez le lien suivant et connectez-vous avec votre compte Audi pour autoriser Home Assistant :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, cliquez sur **Valider**."
+        "description": "Ouvrez le lien suivant et connectez-vous avec votre compte Audi pour autoriser Home Assistant :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, cliquez sur **OK**."
       },
       "reauth_confirm": {
         "title": "Réauthentification Audi",
-        "description": "Votre autorisation Audi a expiré. Ouvrez le lien suivant et reconnectez-vous :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, cliquez sur **Valider**."
+        "description": "Votre autorisation Audi a expiré. Ouvrez le lien suivant et reconnectez-vous :\n\n[{verification_uri}]({verification_uri})\n\nSi un code vous est demandé, saisissez : **{user_code}**\n\nUne fois la demande approuvée, cliquez sur **OK**."
       },
       "reconfigure": {
         "title": "Mettre à jour la configuration Audi Connect",

--- a/custom_components/audiconnect/translations/nb.json
+++ b/custom_components/audiconnect/translations/nb.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "Kontoen er allerede konfigurert",
       "reauth_successful": "Ny autentisering var vellykket",
+      "reconfigure_successful": "Rekonfigurering var vellykket",
       "device_auth_failed": "Kunne ikke starte enhetsinnlogging med Audi. Prøv igjen senere."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Innlogging er ennå ikke oppdaget. Godkjenn forespørselen i nettleseren din, og trykk deretter Send.",
+      "authorization_pending": "Innlogging er ennå ikke oppdaget. Godkjenn forespørselen i nettleseren din, og trykk deretter OK.",
       "device_auth_failed": "Enhetsinnlogging mislyktes. Start på nytt."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Logg inn på Audi",
-        "description": "Åpne følgende lenke og logg inn med Audi-kontoen din for å autorisere Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nHvis du blir bedt om en kode, skriv inn: **{user_code}**\n\nNår du har godkjent forespørselen, trykk **Send**."
+        "description": "Åpne følgende lenke og logg inn med Audi-kontoen din for å autorisere Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nHvis du blir bedt om en kode, skriv inn: **{user_code}**\n\nNår du har godkjent forespørselen, trykk **OK**."
       },
       "reauth_confirm": {
         "title": "Autentiser på nytt med Audi",
-        "description": "Audi-autorisasjonen din har utløpt. Åpne følgende lenke og logg inn på nytt:\n\n[{verification_uri}]({verification_uri})\n\nHvis du blir bedt om en kode, skriv inn: **{user_code}**\n\nNår du har godkjent forespørselen, trykk **Send**."
+        "description": "Audi-autorisasjonen din har utløpt. Åpne følgende lenke og logg inn på nytt:\n\n[{verification_uri}]({verification_uri})\n\nHvis du blir bedt om en kode, skriv inn: **{user_code}**\n\nNår du har godkjent forespørselen, trykk **OK**."
       },
       "reconfigure": {
         "title": "Oppdater Audi Connect-konfigurasjon",

--- a/custom_components/audiconnect/translations/nl.json
+++ b/custom_components/audiconnect/translations/nl.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "Dit account is al geconfigureerd",
       "reauth_successful": "Herauthenticatie is geslaagd",
+      "reconfigure_successful": "Herconfiguratie is geslaagd",
       "device_auth_failed": "Kan de apparaataanmelding bij Audi niet starten. Probeer het later opnieuw."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Aanmelding nog niet gedetecteerd. Keur het verzoek goed in uw browser en klik daarna op Verzenden.",
+      "authorization_pending": "Aanmelding nog niet gedetecteerd. Keur het verzoek goed in uw browser en klik daarna op OK.",
       "device_auth_failed": "Apparaataanmelding mislukt. Begin opnieuw."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Aanmelden bij Audi",
-        "description": "Open de volgende link en meld u aan met uw Audi-account om Home Assistant te autoriseren:\n\n[{verification_uri}]({verification_uri})\n\nAls om een code wordt gevraagd, voer in: **{user_code}**\n\nZodra u het verzoek hebt goedgekeurd, klikt u op **Verzenden**."
+        "description": "Open de volgende link en meld u aan met uw Audi-account om Home Assistant te autoriseren:\n\n[{verification_uri}]({verification_uri})\n\nAls om een code wordt gevraagd, voer in: **{user_code}**\n\nZodra u het verzoek hebt goedgekeurd, klikt u op **OK**."
       },
       "reauth_confirm": {
         "title": "Opnieuw authenticeren bij Audi",
-        "description": "Uw Audi-autorisatie is verlopen. Open de volgende link en meld u opnieuw aan:\n\n[{verification_uri}]({verification_uri})\n\nAls om een code wordt gevraagd, voer in: **{user_code}**\n\nZodra u het verzoek hebt goedgekeurd, klikt u op **Verzenden**."
+        "description": "Uw Audi-autorisatie is verlopen. Open de volgende link en meld u opnieuw aan:\n\n[{verification_uri}]({verification_uri})\n\nAls om een code wordt gevraagd, voer in: **{user_code}**\n\nZodra u het verzoek hebt goedgekeurd, klikt u op **OK**."
       },
       "reconfigure": {
         "title": "Audi Connect-configuratie bijwerken",

--- a/custom_components/audiconnect/translations/pt-BR.json
+++ b/custom_components/audiconnect/translations/pt-BR.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "A conta já foi configurada",
       "reauth_successful": "A reautenticação foi bem-sucedida",
+      "reconfigure_successful": "A reconfiguração foi bem-sucedida",
       "device_auth_failed": "Não foi possível iniciar o login do dispositivo com a Audi. Tente novamente mais tarde."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Login ainda não detectado. Aprove a solicitação no seu navegador e depois clique em Enviar.",
+      "authorization_pending": "Login ainda não detectado. Aprove a solicitação no seu navegador e depois clique em OK.",
       "device_auth_failed": "O login do dispositivo falhou. Comece novamente."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Fazer login na Audi",
-        "description": "Abra o link a seguir e faça login com a sua conta Audi para autorizar o Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nSe um código for solicitado, digite: **{user_code}**\n\nApós aprovar a solicitação, clique em **Enviar**."
+        "description": "Abra o link a seguir e faça login com a sua conta Audi para autorizar o Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nSe um código for solicitado, digite: **{user_code}**\n\nApós aprovar a solicitação, clique em **OK**."
       },
       "reauth_confirm": {
         "title": "Reautenticar com a Audi",
-        "description": "A sua autorização Audi expirou. Abra o link a seguir e faça login novamente:\n\n[{verification_uri}]({verification_uri})\n\nSe um código for solicitado, digite: **{user_code}**\n\nApós aprovar a solicitação, clique em **Enviar**."
+        "description": "A sua autorização Audi expirou. Abra o link a seguir e faça login novamente:\n\n[{verification_uri}]({verification_uri})\n\nSe um código for solicitado, digite: **{user_code}**\n\nApós aprovar a solicitação, clique em **OK**."
       },
       "reconfigure": {
         "title": "Atualizar a configuração do Audi Connect",

--- a/custom_components/audiconnect/translations/pt.json
+++ b/custom_components/audiconnect/translations/pt.json
@@ -3,11 +3,12 @@
     "abort": {
       "already_configured": "A conta já foi configurada",
       "reauth_successful": "A reautenticação foi bem-sucedida",
+      "reconfigure_successful": "A reconfiguração foi bem-sucedida",
       "device_auth_failed": "Não foi possível iniciar o início de sessão do dispositivo com a Audi. Tente novamente mais tarde."
     },
     "create_entry": {},
     "error": {
-      "authorization_pending": "Início de sessão ainda não detetado. Aprove o pedido no seu navegador e depois prima Enviar.",
+      "authorization_pending": "Início de sessão ainda não detetado. Aprove o pedido no seu navegador e depois prima OK.",
       "device_auth_failed": "O início de sessão do dispositivo falhou. Comece novamente."
     },
     "step": {
@@ -27,11 +28,11 @@
       },
       "device": {
         "title": "Iniciar sessão na Audi",
-        "description": "Abra a ligação seguinte e inicie sessão com a sua conta Audi para autorizar o Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nSe lhe for pedido um código, introduza: **{user_code}**\n\nApós aprovar o pedido, prima **Enviar**."
+        "description": "Abra a ligação seguinte e inicie sessão com a sua conta Audi para autorizar o Home Assistant:\n\n[{verification_uri}]({verification_uri})\n\nSe lhe for pedido um código, introduza: **{user_code}**\n\nApós aprovar o pedido, prima **OK**."
       },
       "reauth_confirm": {
         "title": "Reautenticar com a Audi",
-        "description": "A sua autorização Audi expirou. Abra a ligação seguinte e inicie sessão novamente:\n\n[{verification_uri}]({verification_uri})\n\nSe lhe for pedido um código, introduza: **{user_code}**\n\nApós aprovar o pedido, prima **Enviar**."
+        "description": "A sua autorização Audi expirou. Abra a ligação seguinte e inicie sessão novamente:\n\n[{verification_uri}]({verification_uri})\n\nSe lhe for pedido um código, introduza: **{user_code}**\n\nApós aprovar o pedido, prima **OK**."
       },
       "reconfigure": {
         "title": "Atualizar a configuração do Audi Connect",


### PR DESCRIPTION
Follow-up to #777/#778, targeting `beta` as requested in #777. Three small config-flow fixes, all found while chasing the "empty pop-up on reconfigure" reports in #775:

**1. Empty reconfigure dialog after updating from 2.2.0.** The 2.2.0 reconfigure description interpolates `{username}`, and the frontend caches integration translations per browser session. A tab that was open before the update still uses the old string, but the new flow no longer supplies the value - formatjs fails hard (`MISSING_VALUE: "username" was not provided`, exactly the log posted in #775) and the dialog renders empty. That's why switching browsers "fixes" it. The flow now passes the entry title as `username` again: cached 2.2.0 strings render fine, current strings just ignore the extra placeholder.

**2. Raw `reconfigure_successful` shown after saving.** Core ends a reconfigure flow by aborting with that reason and we never shipped a string for it, so the closing dialog literally shows `reconfigure_successful` (HA 2026.7.2). Added it to strings.json and all translations.

**3. The device-code texts point at a button that doesn't exist.** They tell users to press **Submit** ("Senden", "Valider", …), but the dialog's confirm button is labeled **OK** on current HA. Renamed the references.

Not fixable here, but maybe worth a line in the beta release notes: the same per-session translation cache means the *re-auth* dialog can come up completely empty in a tab that was open before the update (the 2.2.0 cache has no `reauth_confirm` step at all) - a hard refresh sorts it. That's probably also behind the "clicking Submit does nothing" reports, since those users never see the sign-in link.