### PR TITLE
feat: region-based authentication (device-code for Europe, password elsewhere)

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -36,11 +36,13 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_PASSWORD,
     CONF_REFRESH_TOKEN,
+    CONF_REGION,
     CONF_SCAN_INITIAL,
     CONF_USERNAME,
     DEFAULT_API_LEVEL,
     DOMAIN,
     PLATFORMS,
+    uses_device_code,
 )
 from .coordinator import AudiDataUpdateCoordinator
 
@@ -94,13 +96,16 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
     if config_entry.version == 2:
         # v2 -> v3:
-        # Authentication moved from username/password (retired by Audi's move to
-        # Play Integrity attestation on the token exchange) to the OAuth Device
-        # Authorization Grant. Drop the stored credentials; the entry has no refresh
-        # token yet, so setup will start a reauthentication (device-code login).
+        # Authentication is now region-dependent. Where Audi enforces Play Integrity
+        # attestation on the token exchange (Europe), the username/password login can
+        # no longer complete, so the credentials are dropped and setup starts a
+        # reauthentication with the Device Authorization Grant. Every other region
+        # keeps its working credentials untouched — wiping them there would break an
+        # account that has no device-code alternative available yet.
         new_data = {**config_entry.data}
-        new_data.pop(CONF_PASSWORD, None)
-        new_data.pop(CONF_USERNAME, None)
+        if uses_device_code(new_data.get(CONF_REGION)):
+            new_data.pop(CONF_PASSWORD, None)
+            new_data.pop(CONF_USERNAME, None)
         hass.config_entries.async_update_entry(config_entry, version=3, data=new_data)
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
@@ -330,10 +335,17 @@ def _async_cleanup_orphaned_devices(
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Audi Connect from a config entry."""
-    if not config_entry.data.get(CONF_REFRESH_TOKEN):
-        # No stored authorization (fresh v2->v3 migration): prompt device-code login.
+    if uses_device_code(config_entry.data.get(CONF_REGION)):
+        if not config_entry.data.get(CONF_REFRESH_TOKEN):
+            # No stored authorization (fresh v2->v3 migration): prompt device-code login.
+            raise ConfigEntryAuthFailed(
+                "Audi Connect needs to sign in again using device-code login"
+            )
+    elif not (
+        config_entry.data.get(CONF_USERNAME) and config_entry.data.get(CONF_PASSWORD)
+    ):
         raise ConfigEntryAuthFailed(
-            "Audi Connect needs to sign in again using device-code login"
+            "Audi Connect needs your myAudi username and password to sign in"
         )
 
     account = AudiAccount(hass, config_entry)

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -33,12 +33,14 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_DURATION,
     CONF_FILTER_VINS,
+    CONF_PASSWORD,
     CONF_REFRESH_AFTER_ACTION,
     CONF_REGION,
     CONF_UPDATE_SLEEP,
     CONF_SPIN,
     CONF_TARGET_SOC,
     CONF_REFRESH_TOKEN,
+    CONF_USERNAME,
     DEFAULT_API_LEVEL,
     DOMAIN,
     REFRESH_VEHICLE_DATA_COMPLETED_EVENT,
@@ -127,6 +129,8 @@ class AudiAccount(AudiConnectObserver):
             api_level=self.config_entry.data.get(CONF_API_LEVEL, DEFAULT_API_LEVEL),
             excluded_vins=excluded_vins,
             refresh_token=self.config_entry.data.get(CONF_REFRESH_TOKEN),
+            username=self.config_entry.data.get(CONF_USERNAME),
+            password=self.config_entry.data.get(CONF_PASSWORD),
         )
         self.connection.add_observer(self)
         self.connection.set_refresh_token_listener(self._persist_refresh_token)

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -46,11 +46,17 @@ class AudiConnectAccount:
         api_level: int,
         excluded_vins: list[str] | None = None,
         refresh_token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
     ) -> None:
         self._api = AudiAPI(session)
         self._audi_service = AudiService(self._api, country, spin, api_level)
 
+        # Either a device-code refresh token (Europe) or username/password
+        # (regions where Audi has not enforced Play Integrity attestation).
         self._refresh_token = refresh_token
+        self._username = username
+        self._password = password
         self._loggedin = False
         self._support_vehicle_refresh = True
         self._logintime: float = 0
@@ -112,8 +118,13 @@ class AudiConnectAccount:
         for observer in self._observers:
             await observer.handle_notification(vin, action)
 
+    @property
+    def uses_password_login(self) -> bool:
+        """True when this account authenticates with username/password."""
+        return not self._refresh_token and bool(self._username and self._password)
+
     async def login(self):
-        if not self._refresh_token:
+        if not self._refresh_token and not self.uses_password_login:
             raise AudiAuthError("No stored authorization; reauthentication is required")
         for i in range(self._connect_retries):
             self._loggedin = await self.try_login(i == self._connect_retries - 1)
@@ -130,26 +141,30 @@ class AudiConnectAccount:
 
     async def try_login(self, logError):
         try:
-            _LOGGER.debug("LOGIN: Refreshing Audi session from stored token...")
-            new_refresh_token = await self._audi_service.login_with_refresh_token(
-                self._refresh_token
-            )
-            if new_refresh_token and new_refresh_token != self._refresh_token:
-                self._refresh_token = new_refresh_token
-                if self._on_refresh_token_update is not None:
-                    self._on_refresh_token_update(new_refresh_token)
+            if self._refresh_token:
+                _LOGGER.debug("LOGIN: Refreshing Audi session from stored token...")
+                new_refresh_token = await self._audi_service.login_with_refresh_token(
+                    self._refresh_token
+                )
+                if new_refresh_token and new_refresh_token != self._refresh_token:
+                    self._refresh_token = new_refresh_token
+                    if self._on_refresh_token_update is not None:
+                        self._on_refresh_token_update(new_refresh_token)
+            else:
+                _LOGGER.debug("LOGIN: Signing in to the Audi service with credentials")
+                await self._audi_service.login(self._username, self._password)
             _LOGGER.debug("LOGIN: Audi session established")
             return True
         except AudiAuthError:
-            # Token rejected (expired/revoked): propagate so Home Assistant reauth
-            # is triggered instead of retrying a credential that can never work.
+            # Credentials/token rejected: propagate so Home Assistant starts reauth
+            # instead of retrying something that can never work.
             raise
         except Exception as exception:
             if logError is True:
                 _LOGGER.error(
                     "LOGIN: Failed to establish an Audi session: %s. "
-                    "Your stored authorization may have expired; reconfigure the "
-                    "Audi Connect integration to sign in again.",
+                    "Your stored credentials may no longer be valid; reconfigure "
+                    "the Audi Connect integration to sign in again.",
                     str(exception),
                 )
             return False

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -5,10 +5,13 @@ import base64
 import hmac
 import json
 import logging
+import os
+import re
+import uuid
 from datetime import datetime, timedelta, timezone
-from hashlib import sha512
+from hashlib import sha256, sha512
 from typing import Any
-from urllib.parse import urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from bs4 import BeautifulSoup
 
@@ -59,6 +62,7 @@ class AudiService:
         self.mbboauthToken = None
         self.xclientId = None
         self._tokenEndpoint = ""
+        self._authorizationEndpoint = ""
         self._bearer_token_json = None
         self._client_id = ""
         self._authorizationServerBaseURLLive = ""
@@ -1233,6 +1237,12 @@ class AudiService:
         if "token_endpoint" in openidcfg_json:
             self._tokenEndpoint = openidcfg_json["token_endpoint"]
 
+        # Authorization endpoint, used by the password (authorization-code) login
+        # that non-European regions still rely on.
+        self._authorizationEndpoint = "https://identity.vwgroup.io/oidc/v1/authorize"
+        if "authorization_endpoint" in openidcfg_json:
+            self._authorizationEndpoint = openidcfg_json["authorization_endpoint"]
+
         # Device Authorization Grant (RFC 8628) endpoint. Discovery advertises it;
         # fall back to the well-known global identity endpoint.
         self._deviceAuthorizationEndpoint = (
@@ -1242,6 +1252,185 @@ class AudiService:
             self._deviceAuthorizationEndpoint = openidcfg_json[
                 "device_authorization_endpoint"
             ]
+
+    async def login(self, user: str, password: str) -> None:
+        """Username/password login (authorization-code flow).
+
+        Retained for the regions where Audi has not (yet) enforced Play Integrity
+        attestation on the token exchange. European accounts must use the Device
+        Authorization Grant instead; see `request_device_code`.
+        """
+        _LOGGER.debug("LOGIN: Starting password login to the Audi service...")
+        await self.login_request(user, password)
+
+    async def login_request(self, user: str, password: str) -> None:
+        await self._discover_endpoints()
+
+        # generate code_challenge
+        code_verifier = str(base64.urlsafe_b64encode(os.urandom(32)), "utf-8").strip(
+            "="
+        )
+        code_challenge = str(
+            base64.urlsafe_b64encode(
+                sha256(code_verifier.encode("ascii", "ignore")).digest()
+            ),
+            "utf-8",
+        ).strip("=")
+        code_challenge_method = "S256"
+
+        state = str(uuid.uuid4())
+        nonce = str(uuid.uuid4())
+
+        # login page
+        headers = {
+            "Accept": "application/json",
+            "Accept-Charset": "utf-8",
+            "X-App-Version": AudiAPI.HDR_XAPP_VERSION,
+            "X-App-Name": "myAudi",
+            "User-Agent": AudiAPI.HDR_USER_AGENT,
+        }
+        idk_data = {
+            "response_type": "code",
+            "client_id": self._client_id,
+            "redirect_uri": "myaudi:///",
+            "scope": "address profile badge birthdate birthplace nationalIdentifier nationality profession email vin phone nickname name picture mbb gallery openid",
+            "state": state,
+            "nonce": nonce,
+            "prompt": "login",
+            "code_challenge": code_challenge,
+            "code_challenge_method": code_challenge_method,
+            "ui_locales": "de-de de",
+        }
+        idk_rsp, idk_rsptxt = await self._api.request(
+            "GET",
+            self._authorizationEndpoint,
+            None,
+            headers=headers,
+            params=idk_data,
+            rsp_wtxt=True,
+        )
+
+        # form_data with email
+        submit_data = self.get_hidden_html_input_form_data(idk_rsptxt, {"email": user})
+        submit_url = self.get_post_url(idk_rsptxt, self._authorizationEndpoint)
+        # send email
+        email_rsp, email_rsptxt = await self._api.request(
+            "POST",
+            submit_url,
+            submit_data,
+            headers=headers,
+            cookies=idk_rsp.cookies,
+            allow_redirects=True,
+            rsp_wtxt=True,
+        )
+
+        # form_data with password
+        # 2022-01-29: new HTML response uses js to build the html form data + button.
+        #             Therefore it's not possible to extract hmac and other form data.
+        #             --> extract hmac from embedded js snippet.
+        regex_res = re.findall('"hmac"\\s*:\\s*"[0-9a-fA-F]+"', email_rsptxt)
+        if regex_res:
+            submit_url = submit_url.replace("identifier", "authenticate")
+            submit_data["hmac"] = regex_res[0].split(":")[1].strip('"')
+            submit_data["password"] = password
+        else:
+            submit_data = self.get_hidden_html_input_form_data(
+                email_rsptxt, {"password": password}
+            )
+            submit_url = self.get_post_url(email_rsptxt, submit_url)
+
+        # send password
+        pw_rsp, _pw_rsptxt = await self._api.request(
+            "POST",
+            submit_url,
+            submit_data,
+            headers=headers,
+            cookies=idk_rsp.cookies,
+            allow_redirects=False,
+            rsp_wtxt=True,
+        )
+
+        # forward1 after pwd
+        if "Location" not in pw_rsp.headers:
+            raise AudiAuthError(
+                "Login redirect missing after password submission (HTTP %d). "
+                "Audi may be showing a consent or terms-of-service prompt. "
+                "Please log in to myAudi via a browser or the myAudi app and "
+                "accept any pending agreements, then restart the integration."
+                % pw_rsp.status
+            )
+        fwd1_rsp, _fwd1_rsptxt = await self._api.request(
+            "GET",
+            pw_rsp.headers["Location"],
+            None,
+            headers=headers,
+            cookies=idk_rsp.cookies,
+            allow_redirects=False,
+            rsp_wtxt=True,
+        )
+        # forward2 after pwd
+        fwd2_rsp, _fwd2_rsptxt = await self._api.request(
+            "GET",
+            fwd1_rsp.headers["Location"],
+            None,
+            headers=headers,
+            cookies=idk_rsp.cookies,
+            allow_redirects=False,
+            rsp_wtxt=True,
+        )
+        # get tokens
+        codeauth_rsp, _codeauth_rsptxt = await self._api.request(
+            "GET",
+            fwd2_rsp.headers["Location"],
+            None,
+            headers=headers,
+            cookies=fwd2_rsp.cookies,
+            allow_redirects=False,
+            rsp_wtxt=True,
+        )
+        authcode_parsed = urlparse(
+            codeauth_rsp.headers["Location"][len("myaudi:///?") :]
+        )
+        authcode_strings = parse_qs(authcode_parsed.path)
+
+        headers = {
+            "Accept": "application/json",
+            "Accept-Charset": "utf-8",
+            "X-QMAuth": self._calculate_X_QMAuth(),
+            "User-Agent": AudiAPI.HDR_USER_AGENT,
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        tokenreq_data = {
+            "client_id": self._client_id,
+            "grant_type": "authorization_code",
+            "code": authcode_strings["code"][0],
+            "redirect_uri": "myaudi:///",
+            "response_type": "token id_token",
+            "code_verifier": code_verifier,
+        }
+        encoded_tokenreq_data = urlencode(tokenreq_data, encoding="utf-8").replace(
+            "+", "%20"
+        )
+        _bearer_token_rsp, bearer_token_rsptxt = await self._api.request(
+            "POST",
+            self._tokenEndpoint,
+            encoded_tokenreq_data,
+            headers=headers,
+            allow_redirects=False,
+            rsp_wtxt=True,
+        )
+        bearer_token_json = json.loads(bearer_token_rsptxt)
+        if "access_token" not in bearer_token_json:
+            # In Europe this is where Play Integrity attestation rejects the
+            # exchange ("invalid assertion headers"); surface it clearly rather
+            # than failing later with a KeyError.
+            raise AudiAuthError(
+                "Password login rejected at the token exchange: "
+                + str(bearer_token_json.get("error", bearer_token_rsptxt[:200]))
+            )
+        self._bearer_token_json = bearer_token_json
+
+        await self._finalize_session()
 
     async def request_device_code(self) -> dict[str, Any]:
         """Start the OAuth Device Authorization Grant (RFC 8628).

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -20,13 +20,17 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
     SelectSelectorMode,
     TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
 )
 
 from .audi_connect_account import AudiConnectAccount
+from .audi_services import AudiAuthError
 from .const import (
     API_LEVELS,
     CONF_API_LEVEL,
     CONF_FILTER_VINS,
+    CONF_PASSWORD,
     CONF_REFRESH_AFTER_ACTION,
     CONF_REFRESH_TOKEN,
     CONF_REGION,
@@ -34,12 +38,14 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_SPIN,
     CONF_UPDATE_SLEEP,
+    CONF_USERNAME,
     DEFAULT_API_LEVEL,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     UPDATE_SLEEP,
     MIN_UPDATE_INTERVAL,
     REGIONS,
+    uses_device_code,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,13 +65,17 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
         self._user_code: str | None = None
         self._reauth_entry: ConfigEntry | None = None
 
-    def _build_connection(self) -> AudiConnectAccount:
+    def _build_connection(
+        self, username: str | None = None, password: str | None = None
+    ) -> AudiConnectAccount:
         session = async_get_clientsession(self.hass)
         return AudiConnectAccount(
             session=session,
             country=self._flow_data[CONF_REGION],
             spin=self._flow_data.get(CONF_SPIN),
             api_level=self._flow_data.get(CONF_API_LEVEL, DEFAULT_API_LEVEL),
+            username=username,
+            password=password,
         )
 
     async def async_step_user(
@@ -81,7 +91,9 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
                     MIN_UPDATE_INTERVAL,
                 ),
             }
-            return await self.async_step_device()
+            if uses_device_code(self._flow_data[CONF_REGION]):
+                return await self.async_step_device()
+            return await self.async_step_credentials()
 
         return self.async_show_form(
             step_id="user",
@@ -112,6 +124,70 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                 }
             ),
+        )
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Username/password sign-in, for regions without attestation."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
+            connection = self._build_connection(username, password)
+            try:
+                if await connection.try_login(False):
+                    return await self._finish_password_login(username, password)
+                errors["base"] = "invalid_credentials"
+            except AudiAuthError:
+                errors["base"] = "invalid_credentials"
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Audi password login failed")
+                errors["base"] = "unexpected"
+
+        step_id = (
+            "reauth_credentials" if self._reauth_entry is not None else "credentials"
+        )
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USERNAME,
+                        default=(user_input or {}).get(CONF_USERNAME, ""),
+                    ): str,
+                    vol.Required(CONF_PASSWORD): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+    async def _finish_password_login(
+        self, username: str, password: str
+    ) -> ConfigFlowResult:
+        """Persist a username/password entry (or update it on reauth)."""
+        if self._reauth_entry is not None:
+            return self.async_update_reload_and_abort(
+                self._reauth_entry,
+                data={
+                    **self._reauth_entry.data,
+                    CONF_USERNAME: username,
+                    CONF_PASSWORD: password,
+                },
+            )
+
+        await self.async_set_unique_id(username.lower())
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=username,
+            data={
+                **self._flow_data,
+                CONF_USERNAME: username,
+                CONF_PASSWORD: password,
+            },
         )
 
     async def async_step_device(
@@ -205,7 +281,15 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        return await self.async_step_device(user_input)
+        if uses_device_code(self._flow_data.get(CONF_REGION)):
+            return await self.async_step_device(user_input)
+        return await self.async_step_credentials(user_input)
+
+    async def async_step_reauth_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Reauth form id for the credentials path (see async_step_credentials)."""
+        return await self.async_step_credentials(user_input)
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -62,6 +62,7 @@ def uses_device_code(region: str | None) -> bool:
     """Return True when the region must use the device-code login."""
     return (region or REGION_EUROPE) in DEVICE_CODE_REGIONS
 
+
 API_LEVELS: list[int] = [0, 1]
 
 PLATFORMS: list[Platform] = [

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -50,6 +50,18 @@ REGIONS: dict[int, str] = {
     4: REGION_CHINA,
 }
 
+# Regions that must authenticate with the Device Authorization Grant (RFC 8628).
+# Audi enforces Play Integrity attestation on the password (authorization-code)
+# token exchange there, so the legacy login can no longer complete. Every other
+# region keeps username/password, which still works for them. If attestation is
+# rolled out elsewhere, add that region here — nothing else needs to change.
+DEVICE_CODE_REGIONS: set[str] = {REGION_EUROPE}
+
+
+def uses_device_code(region: str | None) -> bool:
+    """Return True when the region must use the device-code login."""
+    return (region or REGION_EUROPE) in DEVICE_CODE_REGIONS
+
 API_LEVELS: list[int] = [0, 1]
 
 PLATFORMS: list[Platform] = [
@@ -96,5 +108,7 @@ __all__ = [
     "REFRESH_VEHICLE_DATA_COMPLETED_EVENT",
     "REFRESH_VEHICLE_DATA_FAILED_EVENT",
     "REGIONS",
+    "DEVICE_CODE_REGIONS",
+    "uses_device_code",
     "UPDATE_SLEEP",
 ]

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Sign-in not detected yet. Approve the request in your browser, then press OK.",
-      "device_auth_failed": "Device sign-in failed. Please start again."
+      "device_auth_failed": "Device sign-in failed. Please start again.",
+      "invalid_credentials": "Invalid credentials"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "Optional S-PIN for vehicle actions such as lock/unlock.",
           "region": "The region associated with your Audi Connect account.",
           "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models."
+        }
+      },
+      "credentials": {
+        "title": "Sign in to Audi",
+        "description": "Enter your myAudi username and password.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Re-authenticate with Audi",
+        "description": "Your Audi sign-in is no longer working. Enter your credentials again.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
         }
       }
     }
@@ -123,11 +140,11 @@
         },
         "temp_f": {
           "name": "Target Temperature (Fahrenheit)",
-          "description": "(Optional) Set temperature in \u00b0F. Defaults to 70\u00b0F if not provided. Overrides 'temp_c'."
+          "description": "(Optional) Set temperature in °F. Defaults to 70°F if not provided. Overrides 'temp_c'."
         },
         "temp_c": {
           "name": "Target Temperature (Celsius)",
-          "description": "(Optional) Set temperature in \u00b0C. Defaults to 21\u00b0C if not provided. Overridden if 'temp_f' is provided."
+          "description": "(Optional) Set temperature in °C. Defaults to 21°C if not provided. Overridden if 'temp_f' is provided."
         },
         "glass_heating": {
           "name": "Glass Surface Heating",

--- a/custom_components/audiconnect/translations/de.json
+++ b/custom_components/audiconnect/translations/de.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Anmeldung noch nicht erkannt. Bestätigen Sie die Anfrage in Ihrem Browser und klicken Sie dann auf OK.",
-      "device_auth_failed": "Die Geräteanmeldung ist fehlgeschlagen. Bitte beginnen Sie erneut."
+      "device_auth_failed": "Die Geräteanmeldung ist fehlgeschlagen. Bitte beginnen Sie erneut.",
+      "invalid_credentials": "Ungültige Anmeldeinformationen"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "Optionale S-PIN für Fahrzeugaktionen wie Ver-/Entriegeln.",
           "region": "Die Ihrem Audi Connect-Konto zugeordnete Region.",
           "api_level": "Bei Audi-Fahrzeugen variiert die Struktur der API-Anfragen je nach Modell. Neuere Fahrzeuge verwenden eine aktualisierte Datenstruktur als ältere Modelle."
+        }
+      },
+      "credentials": {
+        "title": "Bei Audi anmelden",
+        "description": "Geben Sie Ihren myAudi-Benutzernamen und Ihr Passwort ein.",
+        "data": {
+          "username": "Benutzername",
+          "password": "Passwort"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Erneut bei Audi authentifizieren",
+        "description": "Ihre Audi-Anmeldung funktioniert nicht mehr. Geben Sie Ihre Zugangsdaten erneut ein.",
+        "data": {
+          "username": "Benutzername",
+          "password": "Passwort"
         }
       }
     }

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Sign-in not detected yet. Approve the request in your browser, then press OK.",
-      "device_auth_failed": "Device sign-in failed. Please start again."
+      "device_auth_failed": "Device sign-in failed. Please start again.",
+      "invalid_credentials": "Invalid credentials"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "Optional S-PIN for vehicle actions such as lock/unlock.",
           "region": "The region associated with your Audi Connect account.",
           "api_level": "For Audi vehicles, the API request data structure varies by model. Newer vehicles use an updated data structure compared to older models."
+        }
+      },
+      "credentials": {
+        "title": "Sign in to Audi",
+        "description": "Enter your myAudi username and password.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Re-authenticate with Audi",
+        "description": "Your Audi sign-in is no longer working. Enter your credentials again.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
         }
       }
     }
@@ -123,11 +140,11 @@
         },
         "temp_f": {
           "name": "Target Temperature (Fahrenheit)",
-          "description": "(Optional) Set temperature in \u00b0F. Defaults to 70\u00b0F if not provided. Overrides 'temp_c'."
+          "description": "(Optional) Set temperature in °F. Defaults to 70°F if not provided. Overrides 'temp_c'."
         },
         "temp_c": {
           "name": "Target Temperature (Celsius)",
-          "description": "(Optional) Set temperature in \u00b0C. Defaults to 21\u00b0C if not provided. Overridden if 'temp_f' is provided."
+          "description": "(Optional) Set temperature in °C. Defaults to 21°C if not provided. Overridden if 'temp_f' is provided."
         },
         "glass_heating": {
           "name": "Glass Surface Heating",

--- a/custom_components/audiconnect/translations/fi.json
+++ b/custom_components/audiconnect/translations/fi.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Kirjautumista ei ole vielä havaittu. Hyväksy pyyntö selaimessasi ja paina sitten OK.",
-      "device_auth_failed": "Laitekirjautuminen epäonnistui. Aloita uudelleen."
+      "device_auth_failed": "Laitekirjautuminen epäonnistui. Aloita uudelleen.",
+      "invalid_credentials": "Virheelliset tunnistetiedot"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "Valinnainen S-PIN ajoneuvon toimintoihin, kuten lukitseminen/avaaminen.",
           "region": "Audi Connect -tiliisi liitetty alue.",
           "api_level": "Audi-ajoneuvoissa API-pyyntöjen rakenne vaihtelee mallin mukaan. Uudemmat ajoneuvot käyttävät päivitettyä tietorakennetta vanhempiin malleihin verrattuna."
+        }
+      },
+      "credentials": {
+        "title": "Kirjaudu Audiin",
+        "description": "Anna myAudi-käyttäjätunnuksesi ja salasanasi.",
+        "data": {
+          "username": "Käyttäjätunnus",
+          "password": "Salasana"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Todenna uudelleen Audiin",
+        "description": "Audi-kirjautumisesi ei enää toimi. Anna tunnistetietosi uudelleen.",
+        "data": {
+          "username": "Käyttäjätunnus",
+          "password": "Salasana"
         }
       }
     }

--- a/custom_components/audiconnect/translations/fr.json
+++ b/custom_components/audiconnect/translations/fr.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Connexion pas encore détectée. Approuvez la demande dans votre navigateur, puis cliquez sur OK.",
-      "device_auth_failed": "La connexion par code a échoué. Veuillez recommencer."
+      "device_auth_failed": "La connexion par code a échoué. Veuillez recommencer.",
+      "invalid_credentials": "Informations d'identification invalides"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "S-PIN optionnel pour les actions sur le véhicule telles que le verrouillage/déverrouillage.",
           "region": "La région associée à votre compte Audi Connect.",
           "api_level": "Sur les véhicules Audi, la structure des requêtes API varie selon le modèle. Les véhicules récents utilisent une structure plus moderne que les anciens."
+        }
+      },
+      "credentials": {
+        "title": "Connexion à Audi",
+        "description": "Saisissez votre identifiant et votre mot de passe myAudi.",
+        "data": {
+          "username": "Nom d'utilisateur",
+          "password": "Mot de passe"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Réauthentification Audi",
+        "description": "Votre connexion Audi ne fonctionne plus. Saisissez à nouveau vos identifiants.",
+        "data": {
+          "username": "Nom d'utilisateur",
+          "password": "Mot de passe"
         }
       }
     }

--- a/custom_components/audiconnect/translations/nb.json
+++ b/custom_components/audiconnect/translations/nb.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Innlogging er ennå ikke oppdaget. Godkjenn forespørselen i nettleseren din, og trykk deretter OK.",
-      "device_auth_failed": "Enhetsinnlogging mislyktes. Start på nytt."
+      "device_auth_failed": "Enhetsinnlogging mislyktes. Start på nytt.",
+      "invalid_credentials": "Ugyldige innloggingsopplysninger"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "Valgfri S-PIN for kjøretøyhandlinger som låsing/opplåsing.",
           "region": "Regionen som er knyttet til Audi Connect-kontoen din.",
           "api_level": "For Audi-kjøretøy varierer strukturen på API-forespørsler etter modell. Nyere kjøretøy bruker en oppdatert datastruktur sammenlignet med eldre modeller."
+        }
+      },
+      "credentials": {
+        "title": "Logg inn på Audi",
+        "description": "Skriv inn brukernavnet og passordet ditt for myAudi.",
+        "data": {
+          "username": "Brukernavn",
+          "password": "Passord"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Autentiser på nytt med Audi",
+        "description": "Audi-innloggingen din fungerer ikke lenger. Skriv inn legitimasjonen din på nytt.",
+        "data": {
+          "username": "Brukernavn",
+          "password": "Passord"
         }
       }
     }

--- a/custom_components/audiconnect/translations/nl.json
+++ b/custom_components/audiconnect/translations/nl.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Aanmelding nog niet gedetecteerd. Keur het verzoek goed in uw browser en klik daarna op OK.",
-      "device_auth_failed": "Apparaataanmelding mislukt. Begin opnieuw."
+      "device_auth_failed": "Apparaataanmelding mislukt. Begin opnieuw.",
+      "invalid_credentials": "Ongeldige gebruikersgegevens"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "Optionele S-PIN voor voertuigacties zoals vergrendelen/ontgrendelen.",
           "region": "De regio die aan uw Audi Connect-account is gekoppeld.",
           "api_level": "Bij Audi-voertuigen verschilt de structuur van API-verzoeken per model. Nieuwere voertuigen gebruiken een bijgewerkte datastructuur ten opzichte van oudere modellen."
+        }
+      },
+      "credentials": {
+        "title": "Aanmelden bij Audi",
+        "description": "Voer uw myAudi-gebruikersnaam en wachtwoord in.",
+        "data": {
+          "username": "Gebruikersnaam",
+          "password": "Wachtwoord"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Opnieuw authenticeren bij Audi",
+        "description": "Uw Audi-aanmelding werkt niet meer. Voer uw gegevens opnieuw in.",
+        "data": {
+          "username": "Gebruikersnaam",
+          "password": "Wachtwoord"
         }
       }
     }

--- a/custom_components/audiconnect/translations/pt-BR.json
+++ b/custom_components/audiconnect/translations/pt-BR.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Login ainda não detectado. Aprove a solicitação no seu navegador e depois clique em OK.",
-      "device_auth_failed": "O login do dispositivo falhou. Comece novamente."
+      "device_auth_failed": "O login do dispositivo falhou. Comece novamente.",
+      "invalid_credentials": "Credenciais inválidas"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "S-PIN opcional para ações do veículo como travar/destravar.",
           "region": "A região associada à sua conta Audi Connect.",
           "api_level": "Nos veículos Audi, a estrutura das solicitações de API varia conforme o modelo. Veículos mais novos usam uma estrutura de dados atualizada em comparação com modelos mais antigos."
+        }
+      },
+      "credentials": {
+        "title": "Fazer login na Audi",
+        "description": "Digite seu nome de usuário e senha do myAudi.",
+        "data": {
+          "username": "Nome de usuário",
+          "password": "Senha"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Reautenticar com a Audi",
+        "description": "Seu login da Audi parou de funcionar. Digite suas credenciais novamente.",
+        "data": {
+          "username": "Nome de usuário",
+          "password": "Senha"
         }
       }
     }

--- a/custom_components/audiconnect/translations/pt.json
+++ b/custom_components/audiconnect/translations/pt.json
@@ -9,7 +9,8 @@
     "create_entry": {},
     "error": {
       "authorization_pending": "Início de sessão ainda não detetado. Aprove o pedido no seu navegador e depois prima OK.",
-      "device_auth_failed": "O início de sessão do dispositivo falhou. Comece novamente."
+      "device_auth_failed": "O início de sessão do dispositivo falhou. Comece novamente.",
+      "invalid_credentials": "Credenciais inválidas"
     },
     "step": {
       "user": {
@@ -45,6 +46,22 @@
           "spin": "S-PIN opcional para ações do veículo como bloquear/desbloquear.",
           "region": "A região associada à sua conta Audi Connect.",
           "api_level": "Nos veículos Audi, a estrutura dos pedidos de API varia consoante o modelo. Os veículos mais recentes usam uma estrutura de dados atualizada em comparação com os modelos mais antigos."
+        }
+      },
+      "credentials": {
+        "title": "Iniciar sessão na Audi",
+        "description": "Introduza o seu nome de utilizador e palavra-passe myAudi.",
+        "data": {
+          "username": "Nome de utilizador",
+          "password": "Senha"
+        }
+      },
+      "reauth_credentials": {
+        "title": "Reautenticar com a Audi",
+        "description": "O seu início de sessão Audi deixou de funcionar. Introduza novamente as suas credenciais.",
+        "data": {
+          "username": "Nome de utilizador",
+          "password": "Senha"
         }
       }
     }


### PR DESCRIPTION
Implements the region-based approach discussed in #777: keep the working password login for the regions Audi hasn't touched, and use the Device Authorization Grant where attestation forces it.

## How the choice is made

One decision point, in `const.py`:

```python
DEVICE_CODE_REGIONS: set[str] = {REGION_EUROPE}

def uses_device_code(region: str | None) -> bool:
    return (region or REGION_EUROPE) in DEVICE_CODE_REGIONS
```

When attestation reaches another region, add it to that set — the config flow, the setup guard and the migration all read from this one helper, so nothing else has to change. That's the "switch a couple lines of code" you were after.

Currently: **Europe → device-code**, **USA / Canada / China → password**. Say the word if you'd rather Canada/China went the other way; I grouped them with the US because nothing suggests attestation is enforced there, but nobody has tested them.

## What changed

- **`audi_services.py`** — `login()` / `login_request()` restored. Rather than pasting the old method back, it is rebuilt on the helpers #777 extracted: `_discover_endpoints()` for the prologue and `_finalize_session()` for the AZS/mbboauth tail, so both flows share that code. The token exchange now raises `AudiAuthError` carrying the backend's own error instead of failing later with a `KeyError` — in Europe that's exactly where `invalid assertion headers` surfaces.
- **`audi_connect_account.py`** — takes either a refresh token or username/password; `try_login()` dispatches.
- **`config_flow.py`** — branches after the region is picked: credentials step for legacy regions, device-code step for Europe, same split on reauth.
- **Translations** — `credentials` / `reauth_credentials` steps and `invalid_credentials` added to all 8 shipped languages, reusing the labels that already existed before #777 (no re-translation).

## Migration bug fixed along the way

The v2→v3 migration dropped `CONF_USERNAME` / `CONF_PASSWORD` **unconditionally**. As it stood, a US user upgrading from v2.2.0 would have had working credentials wiped and then been pushed into device-code — the exact breakage this PR exists to prevent. It's now region-aware, and `async_setup_entry` raises a clear reauth prompt for whichever credential type the region expects instead of failing obscurely.

## Testing

- **Europe: verified end to end** just now on my own account against this branch — device code → token → vehicle API → refresh with rotation, all pass. No regression from the refactor.
- **US / Canada / China: not tested.** I have no account outside the EU. The password path is restored from the pre-#777 code, so it should behave exactly as v2.2.0 did, but it needs your confirmation before merge.

## Note on #781

This supersedes #781 — `beautifulsoup4` and the HTML-form helpers are load-bearing again for the password path, so that PR should be closed. I'll close it once you confirm this direction.
