### PR TITLE
fix: fail loudly when the mbboauth token exchange is rejected

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -1658,7 +1658,9 @@ class AudiService:
             # get_climater(), far from the real cause.
             raise AudiAuthError(
                 "mbboauth token exchange failed: %s"
-                % mbboauth_auth_json.get("error_description", mbboauth_auth_rsptxt[:200])
+                % mbboauth_auth_json.get(
+                    "error_description", mbboauth_auth_rsptxt[:200]
+                )
             )
         # store token and expiration time
         self.mbboauthToken = mbboauth_auth_json

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -1651,6 +1651,15 @@ class AudiService:
             rsp_wtxt=True,
         )
         mbboauth_auth_json = json.loads(mbboauth_auth_rsptxt)
+        if "access_token" not in mbboauth_auth_json:
+            # Fail here rather than storing the error body as a token: otherwise
+            # vwToken silently becomes {"error": ...} and only surfaces much later
+            # as KeyError('access_token') in get_tripdata() or a TypeError in
+            # get_climater(), far from the real cause.
+            raise AudiAuthError(
+                "mbboauth token exchange failed: %s"
+                % mbboauth_auth_json.get("error_description", mbboauth_auth_rsptxt[:200])
+            )
         # store token and expiration time
         self.mbboauthToken = mbboauth_auth_json
 


### PR DESCRIPTION
Re-targeted here from jonny190/audi_connect_ha#2, which was opened against the device-code branch before it merged upstream.

## The problem

`_finalize_session()` stores the mbboauth response without checking it:

```python
mbboauth_auth_json = json.loads(mbboauth_auth_rsptxt)
self.mbboauthToken = mbboauth_auth_json     # may be {"error": ..., "error_description": ...}
```

When the exchange is rejected, `mbboauthToken` and `vwToken` silently become an error dict. Login still reports success, and the failure only appears later, in code that has nothing to do with the cause:

```
get_tripdata()  -> KeyError('access_token')            (self.vwToken["access_token"])
get_climater()  -> TypeError: can only concatenate str (not "NoneType") to str
                   (use_token() -> "Bearer " + self.__token.get("access_token"))
```

This is exactly what made the missing `mbb` scope hard to find. The backend was saying precisely what was wrong:

```
400 {"error":"invalid_grant","error_description":
     "Audiences ([09b6cbec-...@apps_vw-dilab_com]) don't match issuer (VWGMBB01DELIV1)."}
```

...and that message was discarded. What surfaced instead was a `KeyError` in trip data, three layers away.

## This PR

Raise `AudiAuthError` carrying the backend's own `error_description` when mbboauth returns no `access_token`. Nine lines, no behaviour change on the success path.

Worth noting it covers more ground than when it was first written: since #791, `_finalize_session()` is shared by **all three** login paths — password, device-code and refresh — so this guards every region rather than just the device-code one.

## Testing

No-op on a healthy login (verified on a European account: the guard isn't hit and the session establishes normally). When the scope or audience is wrong, the login now fails immediately with the backend's message instead of surfacing later as a `KeyError` in trip data.
