### PR TITLE
fix: reconfigure dialog fails with "expected str" when no S-PIN is set

### DIFF
--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -320,7 +320,11 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
                 {
                     vol.Optional(
                         CONF_SPIN,
-                        default=reconfigure_entry.data.get(CONF_SPIN, ""),
+                        # The S-PIN is optional, and an entry created without one
+                        # stores None (not a missing key), so the "" fallback of
+                        # .get() never applies. Coerce it, or the str validator
+                        # rejects the default with "expected str".
+                        default=reconfigure_entry.data.get(CONF_SPIN) or "",
                     ): str,
                     vol.Required(
                         CONF_REGION, default=current_region_key


### PR DESCRIPTION
Opening the **Reconfigure** dialog fails for any entry set up without an S-PIN — the form shows an `expected str` banner and can't be submitted:

## Cause

The S-PIN is optional, and leaving it blank stores `None` rather than omitting the key:

```python
CONF_SPIN: user_input.get(CONF_SPIN)      # -> None when the field is left blank
```

The reconfigure schema then does:

```python
vol.Optional(CONF_SPIN, default=reconfigure_entry.data.get(CONF_SPIN, "")): str
```

`.get(key, "")` only falls back to `""` when the key is **missing**. Here the key exists with value `None`, so the default is `None`, and the `str` validator rejects it:

```
expected str for dictionary value @ data['spin']
```

Reproduced in isolation against the same schema shape:

| stored value | current default | result |
|---|---|---|
| `{"spin": None}` (blank at setup) | `None` | ❌ `expected str for dictionary value @ data['spin']` |
| `{"spin": "1234"}` | `"1234"` | ✅ |
| `{}` (key absent) | `""` | ✅ |

So it only bites entries created without an S-PIN — which is the common case, since the S-PIN is only needed for lock/unlock and engine start.

## Fix

Coerce the default:

```python
default=reconfigure_entry.data.get(CONF_SPIN) or "",
```

Applying it at the schema rather than at write time also repairs entries that **already** have `None` stored, which a write-side fix wouldn't. Verified against all three cases above: the failing one now passes, the other two are unchanged.

