### PR TITLE
fix: keep using the credential the entry already holds (#795)

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -103,7 +103,9 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         # keeps its working credentials untouched — wiping them there would break an
         # account that has no device-code alternative available yet.
         new_data = {**config_entry.data}
-        if uses_device_code(new_data.get(CONF_REGION)):
+        if uses_device_code(new_data.get(CONF_REGION)) and not new_data.get(
+            CONF_REFRESH_TOKEN
+        ):
             new_data.pop(CONF_PASSWORD, None)
             new_data.pop(CONF_USERNAME, None)
         hass.config_entries.async_update_entry(config_entry, version=3, data=new_data)
@@ -335,17 +337,18 @@ def _async_cleanup_orphaned_devices(
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Audi Connect from a config entry."""
-    if uses_device_code(config_entry.data.get(CONF_REGION)):
-        if not config_entry.data.get(CONF_REFRESH_TOKEN):
-            # No stored authorization (fresh v2->v3 migration): prompt device-code login.
-            raise ConfigEntryAuthFailed(
-                "Audi Connect needs to sign in again using device-code login"
-            )
-    elif not (
+    # Accept whichever credential the entry actually holds, regardless of region:
+    # device-code was offered everywhere in 2.2.1b1/b2, so a non-European entry can
+    # hold a perfectly good refresh token. Only prompt when neither is present.
+    has_refresh_token = bool(config_entry.data.get(CONF_REFRESH_TOKEN))
+    has_credentials = bool(
         config_entry.data.get(CONF_USERNAME) and config_entry.data.get(CONF_PASSWORD)
-    ):
+    )
+    if not has_refresh_token and not has_credentials:
         raise ConfigEntryAuthFailed(
-            "Audi Connect needs your myAudi username and password to sign in"
+            "Audi Connect needs to sign in again"
+            if uses_device_code(config_entry.data.get(CONF_REGION))
+            else "Audi Connect needs your myAudi username and password to sign in"
         )
 
     account = AudiAccount(hass, config_entry)

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -45,6 +45,7 @@ from .const import (
     UPDATE_SLEEP,
     MIN_UPDATE_INTERVAL,
     REGIONS,
+    entry_uses_device_code,
     uses_device_code,
 )
 
@@ -281,7 +282,11 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        if uses_device_code(self._flow_data.get(CONF_REGION)):
+        # Re-authenticate with the method this entry already uses, so an entry that
+        # was set up with device-code outside Europe isn't pushed onto the password
+        # login it never had credentials for.
+        assert self._reauth_entry is not None
+        if entry_uses_device_code(self._reauth_entry.data):
             return await self.async_step_device(user_input)
         return await self.async_step_credentials(user_input)
 

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 
 DOMAIN = "audiconnect"
@@ -63,6 +66,22 @@ def uses_device_code(region: str | None) -> bool:
     return (region or REGION_EUROPE) in DEVICE_CODE_REGIONS
 
 
+def entry_uses_device_code(entry_data: Mapping[str, Any]) -> bool:
+    """Return True when this entry should authenticate with the device-code flow.
+
+    Whatever the entry already holds wins over the region default. Device-code was
+    offered to every region in the 2.2.1b1/b2 pre-releases, so an entry outside
+    Europe can legitimately hold a working refresh token; forcing it onto the
+    password login would break a session that is fine. The region only decides for
+    an entry that has no usable credential yet.
+    """
+    if entry_data.get(CONF_REFRESH_TOKEN):
+        return True
+    if entry_data.get(CONF_USERNAME) and entry_data.get(CONF_PASSWORD):
+        return False
+    return uses_device_code(entry_data.get(CONF_REGION))
+
+
 API_LEVELS: list[int] = [0, 1]
 
 PLATFORMS: list[Platform] = [
@@ -110,6 +129,7 @@ __all__ = [
     "REFRESH_VEHICLE_DATA_FAILED_EVENT",
     "REGIONS",
     "DEVICE_CODE_REGIONS",
+    "entry_uses_device_code",
     "uses_device_code",
     "UPDATE_SLEEP",
 ]


### PR DESCRIPTION
Fixes #795 — a regression from my own PR #791, sorry about that.

### What I got wrong

#791 made setup and reauth decide the login method from the **region**. That assumed every non-European entry came from 2.2.0 and therefore held a username/password. It doesn't: **2.2.1b1 and b2 offered the device-code login to every region**, so a Canadian or US entry set up on those pre-releases holds a perfectly good refresh token and no credentials at all.

On b3 those entries take the password branch, find no username/password, raise `ConfigEntryAuthFailed`, and the reauth flow shows the credentials form — which then rejects every attempt, exactly as @Anto79-ops reports (region CA, "invalid signin", fixed by downgrading to b2).

### The fix

Route on the credential the entry **actually holds**, and fall back to the region only when it has none yet:

| entry | before (b3) | after |
| --- | --- | --- |
| CA + refresh token | password → fails | device-code ✔ |
| CA + username/password | password ✔ | password ✔ |
| CA, no credential | password ✔ | password ✔ |
| DE + refresh token | device-code ✔ | device-code ✔ |
| DE, no credential (2.2.0 migration) | device-code ✔ | device-code ✔ |

- `async_setup_entry` now raises `ConfigEntryAuthFailed` only when **neither** credential is present.
- `async_step_reauth_confirm` re-authenticates with the method the entry uses.
- the v2 → v3 migration no longer drops credentials when a refresh token is already stored (defensive; that combination shouldn't occur, but wiping it would be unrecoverable).

`AudiConnectAccount.try_login()` already prefers the refresh token when one is present, so the account layer needed no change — only the setup guard and the reauth routing were at fault.

### Testing

I can only test region DE (Audi A3 Sportback e-tron 1.4 TFSI, MY2018, France) — device-code path unaffected and still signs in. The seven credential/region combinations above were checked against the routing helper directly. A confirmation from @Anto79-ops on CA would be very welcome.

*Prepared with AI assistance; reviewed by me.*
