### PR TITLE
fix: reload when entry data changes, not just options

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -121,6 +121,7 @@ class AudiRuntimeData:
     account: AudiAccount
     coordinator: AudiDataUpdateCoordinator
     options_snapshot: dict[str, Any] = field(default_factory=dict)
+    data_snapshot: dict[str, Any] = field(default_factory=dict)
 
 
 def _resolve_device_to_vin(hass: HomeAssistant, device_id: str) -> str | None:
@@ -177,14 +178,33 @@ def _get_all_coordinators(hass: HomeAssistant) -> list[AudiDataUpdateCoordinator
     return coordinators
 
 
+def _reloadable_data(config_entry: ConfigEntry) -> dict[str, Any]:
+    """Entry data that the running integration is configured from.
+
+    The refresh token is excluded: it rotates on its own during normal operation
+    and reloading on every rotation would tear the integration down for nothing.
+    """
+    return {k: v for k, v in config_entry.data.items() if k != CONF_REFRESH_TOKEN}
+
+
 async def _async_update_listener(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> None:
+    """Reload when the configuration changed, in options *or* in data.
+
+    The S-PIN, region and API level live in entry data, not in options, so
+    comparing options alone would silently skip the reload a reconfigure needs.
+    Home Assistant reloads on its own today, but from 2026.12 it defers to this
+    listener whenever one is registered, and the missed reload would surface as
+    "my new S-PIN is ignored until I restart".
+    """
     runtime_data: AudiRuntimeData | None = getattr(config_entry, "runtime_data", None)
-    if runtime_data is not None and runtime_data.options_snapshot == dict(
-        config_entry.options
+    if (
+        runtime_data is not None
+        and runtime_data.options_snapshot == dict(config_entry.options)
+        and runtime_data.data_snapshot == _reloadable_data(config_entry)
     ):
-        # Only entry data changed (e.g. a rotated refresh token); no reload needed.
+        # Only the refresh token rotated; nothing the running setup depends on.
         return
     await hass.config_entries.async_reload(config_entry.entry_id)
 
@@ -362,6 +382,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         account=account,
         coordinator=coordinator,
         options_snapshot=dict(config_entry.options),
+        data_snapshot=_reloadable_data(config_entry),
     )
 
     config_entry.async_on_unload(


### PR DESCRIPTION
Home Assistant logs this on any reauth or reconfigure:

```
Detected that custom integration 'audiconnect' has an update listener and should
use it for scheduling a reload. This will stop working in Home Assistant 2026.12.0
```

It comes from `async_update_reload_and_abort()`, which reports it when the entry also registers an update listener ([config_entries.py](https://github.com/home-assistant/core/blob/dev/homeassistant/config_entries.py) — `report_usage(..., breaks_in_ha_version="2026.12.0")`). We do both: `add_update_listener(_async_update_listener)` in `async_setup_entry`, and `async_update_reload_and_abort` in three config-flow paths (password login, device login, reconfigure).

### Why this is more than a deprecation notice

Home Assistant schedules the reload itself today, so the listener returning early is harmless. From **2026.12 it stops doing that and defers to the listener**. And the listener bails out whenever the options are unchanged:

```python
if runtime_data is not None and runtime_data.options_snapshot == dict(config_entry.options):
    # Only entry data changed (e.g. a rotated refresh token); no reload needed.
    return
```

But the **S-PIN, region and API level live in entry data, not in options** — they're written by `async_step_reconfigure` via `data_updates`. So after 2026.12, a reconfigure would update the entry and never reload it: a user entering a new S-PIN would find it ignored until the next Home Assistant restart, with nothing in the log to explain why.

### The fix

Snapshot the entry data as well, excluding `refresh_token` — that rotates on its own during normal operation and must not tear the integration down. Excluding one key rather than allow-listing three means a future data key is covered by default.

| change | before | after |
| --- | --- | --- |
| refresh token rotates | no reload | no reload |
| S-PIN set / changed / removed | **no reload** | reload |
| region changed | **no reload** | reload |
| API level changed | **no reload** | reload |
| an option changed | reload | reload |
| nothing changed | no reload | no reload |

Verified against those seven cases.

*Prepared with AI assistance; reviewed by me.*
