### PR TITLE
fix: a 502 while polling the preheater is transient, don't disable it

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1034,19 +1034,21 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404, 502):
+            if cre.status in (403, 404):
                 _LOGGER.debug(
                     "PREHEATER: ClientResponseError with status %s for VIN: %s. Vehicle does not support preheater — disabling.",
                     cre.status,
                     redacted_vin,
                 )
                 self.support_preheater = False
-            # elif cre.status == 502:
-            #    _LOGGER.warning(
-            #        "PREHEATER: ClientResponseError with status %s while updating preheater for VIN: %s. This issue may resolve in time. If it persists, please open an issue.",
-            #        cre.status,
-            #        redacted_vin,
-            #    )
+            elif cre.status == 502:
+                # Transient CARIAD gateway error; keep the feature enabled so the
+                # next poll can recover, matching the other status endpoints.
+                _LOGGER.debug(
+                    "PREHEATER: Received status %s while updating preheater for VIN: %s. This is typically transient and may resolve on its own.",
+                    cre.status,
+                    redacted_vin,
+                )
             else:
                 self.log_exception_once(
                     cre,


### PR DESCRIPTION
Related to #793.

`update_vehicle_preheater()` lumps `502` in with `403`/`404` and permanently sets `support_preheater = False`. That flag is only ever reset in the constructor, so a **single transient CARIAD gateway error stops the preheater from being polled again until the next restart**.

A `502` is a gateway error, not a "feature unsupported" signal. The other four status endpoints — position, climater, charger, trip data — already treat it as transient and keep polling. Only the preheater doesn't.

This aligns it with the others: on `502`, log at debug and leave the feature enabled so the next poll recovers. A commented-out block right below the handler already anticipated this fix — this finishes it.

| status | before | after |
| --- | --- | --- |
| 403 / 404 | disable feature | disable feature |
| **502** | **disable feature (permanent)** | **transient, keep polling** |
| other | log | log |

Seen in a real debug log (`PREHEATER: ClientResponseError with status 502 ... disabling.`) on a MY2018 A3 e-tron during a backend hiccup.

*Prepared with AI assistance; reviewed by me.*
