### PR TITLE
fix: a 403 is transient, only a 404 disables a feature

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -268,7 +268,7 @@ class AudiConnectAccount:
             )
             return False
         except ClientResponseError as cre:
-            if cre.status in (403, 404):
+            if cre.status == 404:
                 _LOGGER.debug(
                     "VEHICLE REFRESH: ClientResponseError with status %s for VIN: %s. Vehicle does not support vehicle refresh — disabling.",
                     cre.status,
@@ -276,7 +276,7 @@ class AudiConnectAccount:
                 )
                 self._support_vehicle_refresh = False
                 return "disabled"
-            elif cre.status == 502:
+            elif cre.status in (403, 502):
                 _LOGGER.debug(
                     "VEHICLE REFRESH: Received status %s while refreshing vehicle data for VIN: %s. This is typically transient and may resolve on its own.",
                     cre.status,
@@ -779,9 +779,9 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as resp_exception:
-            if resp_exception.status in (403, 404):
+            if resp_exception.status == 404:
                 self.support_status_report = False
-            elif resp_exception.status == 502:
+            elif resp_exception.status in (403, 502):
                 # Transient CARIAD gateway error; the cached state is kept and the
                 # next poll normally recovers. Logged at debug like the other
                 # endpoints, not as an error, to avoid noise.
@@ -884,14 +884,14 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404):
+            if cre.status == 404:
                 _LOGGER.debug(
                     "POSITION: ClientResponseError with status %s for VIN: %s. Vehicle does not support position — disabling.",
                     cre.status,
                     redacted_vin,
                 )
                 self.support_position = False
-            elif cre.status == 502:
+            elif cre.status in (403, 502):
                 _LOGGER.debug(
                     "POSITION: Received status %s while updating vehicle position for VIN: %s. This is typically transient and may resolve on its own.",
                     cre.status,
@@ -985,14 +985,14 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404):
+            if cre.status == 404:
                 _LOGGER.debug(
                     "CLIMATER: ClientResponseError with status %s for VIN: %s. Vehicle does not support climater — disabling.",
                     cre.status,
                     redacted_vin,
                 )
                 self.support_climater = False
-            elif cre.status == 502:
+            elif cre.status in (403, 502):
                 _LOGGER.debug(
                     "CLIMATER: Received status %s while updating climater for VIN: %s. This is typically transient and may resolve on its own.",
                     cre.status,
@@ -1141,14 +1141,14 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404):
+            if cre.status == 404:
                 _LOGGER.debug(
                     "CHARGER: ClientResponseError with status %s for VIN: %s. Vehicle does not support charger — disabling.",
                     cre.status,
                     redacted_vin,
                 )
                 self.support_charger = False
-            elif cre.status == 502:
+            elif cre.status in (403, 502):
                 _LOGGER.debug(
                     "CHARGER: Received status %s while updating charger for VIN: %s. This is typically transient and may resolve on its own.",
                     cre.status,
@@ -1219,14 +1219,14 @@ class AudiConnectVehicle:
             )
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404):
+            if cre.status == 404:
                 _LOGGER.debug(
                     "TRIP DATA: ClientResponseError with status %s for VIN: %s. Vehicle does not support trip data — disabling.",
                     cre.status,
                     redacted_vin,
                 )
                 self.support_trip_data = False
-            elif cre.status == 502:
+            elif cre.status in (403, 502):
                 _LOGGER.debug(
                     "TRIP DATA: Received status %s while updating trip data for VIN: %s. This is typically transient and may resolve on its own.",
                     cre.status,


### PR DESCRIPTION
Related to #793.

Every per-feature status handler — vehicle refresh, status report, position, climater, charger, trip data — treats `403` exactly like `404`: it sets the feature's `support_*` flag to `False`. That flag is only reset in the constructor, so **a single `403` permanently stops that feature from being polled until Home Assistant restarts or the entry reloads**.

But a `403` is not "feature unsupported" — it's a transient authorization state. Audi returns it while an account is being re-verified (primary-user / S-PIN revalidation), and it clears on its own once the backend recovers. Lumping it with `404` turns a temporary account condition into features that stay dark for the rest of the session, with nothing in the UI to explain why. I hit exactly this: a day-long account re-verification returned `403`s, and the only way to get the features back was a restart.

Now only a `404` (endpoint genuinely not found) disables a feature. `403` joins the existing `502` branch: logged at debug, feature kept enabled, next poll recovers.

| status | before | after |
| --- | --- | --- |
| 404 | disable feature | disable feature |
| **403** | **disable feature (permanent)** | **transient, keep polling** |
| 502 | transient | transient |

Applied uniformly across all six handlers in `audi_connect_account.py`.

> **Note for the maintainer:** this overlaps by one line with #799 (the preheater 502 fix) — both touch the preheater handler's `elif` branch. They're independent; whichever merges first, the other needs a trivial one-line rebase on that `elif`. Happy to rebase whichever you take second.

*Prepared with AI assistance; reviewed by me.*
