### PR TITLE
fix: make the preheater 403 transient too, for consistency

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1034,14 +1034,14 @@ class AudiConnectVehicle:
         except TimeoutError:
             raise
         except ClientResponseError as cre:
-            if cre.status in (403, 404):
+            if cre.status == 404:
                 _LOGGER.debug(
                     "PREHEATER: ClientResponseError with status %s for VIN: %s. Vehicle does not support preheater — disabling.",
                     cre.status,
                     redacted_vin,
                 )
                 self.support_preheater = False
-            elif cre.status == 502:
+            elif cre.status in (403, 502):
                 # Transient CARIAD gateway error; keep the feature enabled so the
                 # next poll can recover, matching the other status endpoints.
                 _LOGGER.debug(


### PR DESCRIPTION
Related to #793.

#799 and #800 landed the "transient error" rework in two pieces: #799 split the preheater's `502` out of its disable branch, and #800 made `403` transient in the other six status handlers. Between the two, the preheater was the one handler left still disabling on a `403` — neither PR covered that exact line.

This aligns it with the rest: only a `404` disables the feature; `403` joins the `502` branch as transient. All seven status handlers now behave identically.

| status | preheater before | preheater after |
| --- | --- | --- |
| 404 | disable feature | disable feature |
| **403** | **disable feature** | **transient, keep polling** |
| 502 | transient | transient |

*Prepared with AI assistance; reviewed by me.*
