### PR TITLE
fix: treat a value of 0 as supported for the remaining maintenance/range fields

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -1274,10 +1274,9 @@ class AudiConnectVehicle:
             )
 
     @property
-    def service_inspection_time_supported(self):
+    def service_inspection_time_supported(self) -> bool:
         check = self._vehicle.fields.get("MAINTENANCE_INTERVAL_TIME_TO_INSPECTION")
-        if check and parse_int(check):
-            return True
+        return parse_int(check) is not None
 
     @property
     def service_inspection_distance(self):
@@ -1299,10 +1298,9 @@ class AudiConnectVehicle:
             return int(self._vehicle.fields.get("ADBLUE_RANGE"))
 
     @property
-    def service_adblue_distance_supported(self):
+    def service_adblue_distance_supported(self) -> bool:
         check = self._vehicle.fields.get("ADBLUE_RANGE")
-        if check and parse_int(check):
-            return True
+        return parse_int(check) is not None
 
     @property
     def oil_change_time(self):
@@ -1313,10 +1311,9 @@ class AudiConnectVehicle:
             )
 
     @property
-    def oil_change_time_supported(self):
+    def oil_change_time_supported(self) -> bool:
         check = self._vehicle.fields.get("MAINTENANCE_INTERVAL_TIME_TO_OIL_CHANGE")
-        if check and parse_int(check):
-            return True
+        return parse_int(check) is not None
 
     @property
     def oil_change_distance(self):
@@ -1451,11 +1448,10 @@ class AudiConnectVehicle:
             return parse_int(check)
 
     @property
-    def range_supported(self):
+    def range_supported(self) -> bool:
         """Return true if range is supported"""
         check = self._vehicle.fields.get("TOTAL_RANGE")
-        if check and parse_int(check):
-            return True
+        return parse_int(check) is not None
 
     @property
     def tank_level(self):
@@ -1464,11 +1460,10 @@ class AudiConnectVehicle:
             return parse_int(check)
 
     @property
-    def tank_level_supported(self):
+    def tank_level_supported(self) -> bool:
         """Return true if tank_level is supported"""
         check = self._vehicle.fields.get("TANK_LEVEL_IN_PERCENTAGE")
-        if check and parse_int(check):
-            return True
+        return parse_int(check) is not None
 
     @property
     def position(self):


### PR DESCRIPTION
Follow-up to `fixing value 0` (a149e08), which fixed `service_inspection_distance_supported` and `oil_change_distance_supported`.

Five more `*_supported` properties still use `if check and parse_int(check)`, where a legitimate value of `0` is falsy, so the entity is dropped as "unsupported":

| property | 0 means |
| --- | --- |
| `service_inspection_time` | inspection due now |
| `oil_change_time` | oil change due now |
| `tank_level` | empty tank (0 %) |
| `range` | no range left |
| `service_adblue_distance` | AdBlue empty |

The `*_time` pair are the direct siblings of the `*_distance` pair you just fixed. Same fix applied: `parse_int(check) is not None`, so a real `0` is kept and only a missing/non-numeric field counts as unsupported.

**`mileage` is deliberately left as-is.** An odometer of 0 never occurs on a real vehicle, and mileage feeds `total_increasing` utility meters — surfacing a spurious `0` would book a phantom distance on the rebound. Keeping it hidden on `0` is the safer behaviour there.

*Prepared with AI assistance; reviewed by me.*
