### PR TITLE
fix: use device-code login for Canada (attestation reached CA) (#814)

### DIFF
--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -58,7 +58,12 @@ REGIONS: dict[int, str] = {
 # token exchange there, so the legacy login can no longer complete. Every other
 # region keeps username/password, which still works for them. If attestation is
 # rolled out elsewhere, add that region here — nothing else needs to change.
-DEVICE_CODE_REGIONS: set[str] = {REGION_EUROPE}
+#
+# Canada joined after attestation reached that market too: its market config
+# reports "marketSupportsAppAttestation": True, its login is routed to the same
+# emea.bff.cariad.digital backend as Europe, and that backend advertises the
+# device_code grant — so the same device-code login works there (issue #814).
+DEVICE_CODE_REGIONS: set[str] = {REGION_EUROPE, REGION_CANADA}
 
 
 def uses_device_code(region: str | None) -> bool:


### PR DESCRIPTION
Addresses #814.

Canada now fails the username/password login with "Invalid credentials" on v2.3.0 — the same Play Integrity attestation wall that took out the EU login in July, not a real credential problem. @jasonbwilliams's CA debug log confirms it:

- market config reports **`"marketSupportsAppAttestation": True`**
- CA login is routed to **`emea.bff.cariad.digital`** (in `audi_services.py`, only literal `"US"` uses the `na` backend), the same backend the EU uses
- that backend advertises **`urn:ietf:params:oauth:grant-type:device_code`** in `grant_types_supported`
- the password token exchange returns the attestation error body

Since CA already rides the `emea` backend where device-code works for the EU, adding it to `DEVICE_CODE_REGIONS` is all that's needed — the extension point the constant was built for. This is exactly the one-liner @coreywillwhat proposed on the issue; the log just confirms it should actually work rather than hit the US-style `na` wall.

```python
DEVICE_CODE_REGIONS: set[str] = {REGION_EUROPE, REGION_CANADA}
```

| region | before | after |
| --- | --- | --- |
| DE (EU) | device-code | device-code |
| **CA** | **password (now failing)** | **device-code** |
| US | password | password |
| CN | password | password |

**Testing:** I can't test CA myself (EU account) — verified EU is unchanged and the routing helper returns device-code for CA, password for US/CN. **@jasonbwilliams, this needs an end-to-end test on your CA account** (fresh Add Integration → CA → you should now get the sign-in-link step instead of username/password). Note: an existing CA entry still holding username/password won't switch automatically — remove and re-add it to move onto device-code.

*Prepared with AI assistance; reviewed by me.*
