### PR TITLE
fix: keep last known values when a selectivestatus payload is all errors (#793)

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -758,6 +758,20 @@ class AudiConnectVehicle:
 
         try:
             status = await self._audi_service.get_stored_vehicle_data(self._vehicle.vin)
+            # #793: on a CARIAD outage this comes back 200, but every job is an
+            # error object instead of a value, so it parses to nothing. Assigning
+            # that would wipe every field and the entities quietly disappear, while
+            # the update still reports success. Same handling as the 403/502 case
+            # below: keep the last known values, mark the update failed so it
+            # surfaces, and skip the overwrite.
+            if status.all_jobs_errored:
+                self._no_error = False
+                _LOGGER.warning(
+                    "Vehicle status report for %s came back with only errors "
+                    "(transient CARIAD outage); keeping the last known values.",
+                    self._vehicle.vin,
+                )
+                return
             self._vehicle.fields = {
                 status.data_fields[i].name: status.data_fields[i].value
                 for i in range(len(status.data_fields))

--- a/custom_components/audiconnect/audi_models.py
+++ b/custom_components/audiconnect/audi_models.py
@@ -21,6 +21,22 @@ class CurrentVehicleDataResponse:
         self.vin: str = data["vin"]
 
 
+def _count_error_objects(data: Any) -> int:
+    """Count the ``error`` objects anywhere in a selectivestatus payload.
+
+    On a CARIAD outage the API answers 200 but drops an ``error`` object where the
+    ``value`` should be, for every job. Counting them is how we tell a transient
+    outage from a car that just doesn't have a feature, since both otherwise parse
+    to nothing. See audiconnect/audi_connect_ha#793.
+    """
+    if isinstance(data, dict):
+        here = 1 if "error" in data else 0
+        return here + sum(_count_error_objects(v) for v in data.values())
+    if isinstance(data, list):
+        return sum(_count_error_objects(v) for v in data)
+    return 0
+
+
 class VehicleDataResponse:
     OLDAPI_MAPPING = {
         "frontRightLock": "LOCK_STATE_RIGHT_FRONT_DOOR",
@@ -43,9 +59,18 @@ class VehicleDataResponse:
         "roofCoverWindow": "STATE_ROOF_COVER_WINDOW",
     }
 
+    @property
+    def all_jobs_errored(self) -> bool:
+        """True when the payload had error objects and nothing usable came out of
+        it, so a transient CARIAD outage, not a car that's missing features (#793)."""
+        return self.error_count > 0 and not self.data_fields and not self.states
+
     def __init__(self, data: dict[str, Any]) -> None:
         self.data_fields: list[Field] = []
         self.states: list[dict[str, Any]] = []
+        # #793: count the error objects up front, so an all-error outage (200 but
+        # every job errored) can be told apart from a car that lacks a feature.
+        self.error_count: int = _count_error_objects(data)
 
         self._tryAppendFieldWithTs(
             data, "TOTAL_RANGE", ["fuelStatus", "rangeStatus", "value", "totalRange_km"]

--- a/tests/test_all_jobs_errored.py
+++ b/tests/test_all_jobs_errored.py
@@ -4,6 +4,7 @@ can keep the last known values instead of quietly pruning every entity.
 Composes with the pytest harness from #815 (no network). On its own it just needs
 the package importable.
 """
+
 from __future__ import annotations
 
 from custom_components.audiconnect.audi_models import (

--- a/tests/test_all_jobs_errored.py
+++ b/tests/test_all_jobs_errored.py
@@ -1,0 +1,57 @@
+"""#793: an all-error selectivestatus payload has to be detectable, so the caller
+can keep the last known values instead of quietly pruning every entity.
+
+Composes with the pytest harness from #815 (no network). On its own it just needs
+the package importable.
+"""
+from __future__ import annotations
+
+from custom_components.audiconnect.audi_models import (
+    VehicleDataResponse,
+    _count_error_objects,
+)
+
+# HTTP 200 payload where every job carried an error object (a CARIAD outage).
+_OUTAGE = {
+    "access": {"accessStatus": {"error": {"message": "Bad Gateway", "retry": True}}},
+    "charging": {
+        "batteryStatus": {"error": {"message": "Bad Gateway"}},
+        "chargingStatus": {"error": {"message": "Bad Gateway"}},
+    },
+    "measurements": {
+        "odometerStatus": {"error": {"message": "Bad Gateway"}},
+        "rangeStatus": {"error": {"message": "Bad Gateway"}},
+    },
+}
+
+# A normal payload with real values and no error object.
+_NORMAL = {
+    "measurements": {
+        "odometerStatus": {"value": {"odometer": 42000}},
+        "fuelLevelStatus": {"value": {"currentFuelLevel_pct": 70}},
+    },
+    "fuelStatus": {"rangeStatus": {"value": {"totalRange_km": 480}}},
+}
+
+# A car that simply lacks a feature: no error, just fewer jobs.
+_FEATURELESS = {"access": {"accessStatus": {"value": {"doorLockStatus": "locked"}}}}
+
+
+def test_count_error_objects_counts_every_error() -> None:
+    assert _count_error_objects(_OUTAGE) == 5
+    assert _count_error_objects(_NORMAL) == 0
+    assert _count_error_objects(_FEATURELESS) == 0
+
+
+def test_all_jobs_errored_true_on_outage() -> None:
+    assert VehicleDataResponse(_OUTAGE).all_jobs_errored is True
+
+
+def test_all_jobs_errored_false_on_real_data() -> None:
+    assert VehicleDataResponse(_NORMAL).all_jobs_errored is False
+
+
+def test_featureless_car_is_not_flagged_as_an_outage() -> None:
+    # No error object here, so the "keep last known values" guard must not fire.
+    # A feature the car doesn't have is a real absence, not an outage.
+    assert VehicleDataResponse(_FEATURELESS).all_jobs_errored is False


### PR DESCRIPTION
Fixes part 1 of #793.

On a CARIAD outage the selectivestatus call still comes back as HTTP 200, but every job carries an error object instead of a value. That parses to nothing, and update_vehicle_statusreport then assigns the empty result, so every field gets wiped and the entities silently disappear while the update still reports success: True. After a restart in that state the entity count drops (13 of ~46), last_update sits at 1970, and there's nothing in the log.

This keeps the last known values instead of wiping them, matching how your 403/502 handlers already keep the cached state on a transient gateway error. It also logs a warning so the outage isn't silent, and sets _no_error = False so the account re-logs in on the next cycle, which is what Audi's own payload asks for (retry: True, and the error info literally says "please try to re-login"). The entities keep showing their last values in the meantime rather than vanishing or going unavailable. If you'd rather have them go unavailable during an outage, that's a one-line change (raise instead of keeping state), I went with keep-stale because it matches the rest of the file and avoids flickering ~46 entities on a transient hiccup.

The genuinely missing feature case stays untouched, no error object, so all_jobs_errored is False and the field stays a normal None (no entity), just like before.

- audi_models.py: _count_error_objects() plus an all_jobs_errored property on VehicleDataResponse (only True when there are errors and nothing usable parsed).
- audi_connect_account.py: the guard in update_vehicle_statusreport.
- tests/test_all_jobs_errored.py: 4 tests (outage / real data / featureless car). They compose with the harness in #815, on their own they just need the package importable.

This is scoped to part 1 only. Part 2 (the preheater treating a transient 502 as "unsupported" and disabling it for the session) is separate, happy to take that row too if you want it. Happy to adjust anything to fit your conventions.
