### PR TITLE
fix: start climatisation with the vehicle's own settings when none are given (#771)

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -211,16 +211,19 @@ class AudiAccount(AudiConnectObserver):
 
     async def start_climate_control(self, vin: str, service: ServiceCall) -> None:
         """Start climate control for a vehicle by VIN."""
+        # Pass the fields through as supplied, without substituting defaults, so
+        # the service layer can tell "the caller wants everything left alone"
+        # apart from "the caller explicitly asked for all of it off".
         await self.connection.start_climate_control(
             vin.lower(),
             service.data.get(CONF_CLIMATE_TEMP_F),
             service.data.get(CONF_CLIMATE_TEMP_C),
-            service.data.get(CONF_CLIMATE_GLASS, False),
-            service.data.get(CONF_CLIMATE_SEAT_FL, False),
-            service.data.get(CONF_CLIMATE_SEAT_FR, False),
-            service.data.get(CONF_CLIMATE_SEAT_RL, False),
-            service.data.get(CONF_CLIMATE_SEAT_RR, False),
-            service.data.get(CONF_CLIMATE_AT_UNLOCK, False),
+            service.data.get(CONF_CLIMATE_GLASS),
+            service.data.get(CONF_CLIMATE_SEAT_FL),
+            service.data.get(CONF_CLIMATE_SEAT_FR),
+            service.data.get(CONF_CLIMATE_SEAT_RL),
+            service.data.get(CONF_CLIMATE_SEAT_RR),
+            service.data.get(CONF_CLIMATE_AT_UNLOCK),
             service.data.get(CONF_CLIMATE_MODE),
         )
 

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -419,15 +419,15 @@ class AudiConnectAccount:
     async def start_climate_control(
         self,
         vin: str,
-        temp_f: int,
-        temp_c: int,
-        glass_heating: bool,
-        seat_fl: bool,
-        seat_fr: bool,
-        seat_rl: bool,
-        seat_rr: bool,
-        climatisation_at_unlock: bool,
-        climatisation_mode: str,
+        temp_f: int | None = None,
+        temp_c: int | None = None,
+        glass_heating: bool | None = None,
+        seat_fl: bool | None = None,
+        seat_fr: bool | None = None,
+        seat_rl: bool | None = None,
+        seat_rr: bool | None = None,
+        climatisation_at_unlock: bool | None = None,
+        climatisation_mode: str | None = None,
     ):
         if not self._loggedin:
             await self.login()

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -620,15 +620,15 @@ class AudiService:
     async def start_climate_control(
         self,
         vin: str,
-        temp_f: int,
-        temp_c: int,
-        glass_heating: bool,
-        seat_fl: bool,
-        seat_fr: bool,
-        seat_rl: bool,
-        seat_rr: bool,
-        climatisation_at_unlock: bool = False,
-        climatisation_mode: str = "comfort",
+        temp_f: int | None = None,
+        temp_c: int | None = None,
+        glass_heating: bool | None = None,
+        seat_fl: bool | None = None,
+        seat_fr: bool | None = None,
+        seat_rl: bool | None = None,
+        seat_rr: bool | None = None,
+        climatisation_at_unlock: bool | None = None,
+        climatisation_mode: str | None = None,
     ):
         api_level = self._api_level
         country = self._country
@@ -652,10 +652,10 @@ class AudiService:
 
             # Construct Zone Settings
             zone_settings = [
-                {"value": {"isEnabled": seat_fl, "position": "frontLeft"}},
-                {"value": {"isEnabled": seat_fr, "position": "frontRight"}},
-                {"value": {"isEnabled": seat_rl, "position": "rearLeft"}},
-                {"value": {"isEnabled": seat_rr, "position": "rearRight"}},
+                {"value": {"isEnabled": bool(seat_fl), "position": "frontLeft"}},
+                {"value": {"isEnabled": bool(seat_fr), "position": "frontRight"}},
+                {"value": {"isEnabled": bool(seat_rl), "position": "rearLeft"}},
+                {"value": {"isEnabled": bool(seat_rr), "position": "rearRight"}},
             ]
 
             data = {
@@ -717,27 +717,55 @@ class AudiService:
             )
 
         elif api_level == 1:
-            if temp_f is not None:
-                target_temperature = int((temp_f - 32) * (5 / 9))
-            elif temp_c is not None:
-                target_temperature = int(temp_c)
+            # Some vehicles (for example the Q6 e-tron) reject a settings payload
+            # outright, because they have no comfort climatisation profile to apply
+            # it to. The vehicle reports the request as failed only after it has
+            # synchronised, so the failure shows up in the myAudi app rather than
+            # in our HTTP response. When the caller supplied no settings at all,
+            # send no body and let the vehicle use the settings stored in the car,
+            # which is what the myAudi app does in that case.
+            has_settings = any(
+                value is not None
+                for value in (
+                    temp_f,
+                    temp_c,
+                    climatisation_mode,
+                    climatisation_at_unlock,
+                    glass_heating,
+                    seat_fl,
+                    seat_fr,
+                    seat_rl,
+                    seat_rr,
+                )
+            )
 
-            target_temperature = target_temperature or 21
+            data = None
+            if has_settings:
+                if temp_f is not None:
+                    target_temperature = int((temp_f - 32) * (5 / 9))
+                elif temp_c is not None:
+                    target_temperature = int(temp_c)
 
-            data = {
-                "climatisationMode": climatisation_mode,
-                "targetTemperature": target_temperature,
-                "targetTemperatureUnit": "celsius",
-                "climatisationWithoutExternalPower": True,
-                "climatizationAtUnlock": climatisation_at_unlock,
-                "windowHeatingEnabled": glass_heating,
-                "zoneFrontLeftEnabled": seat_fl,
-                "zoneFrontRightEnabled": seat_fr,
-                "zoneRearLeftEnabled": seat_rl,
-                "zoneRearRightEnabled": seat_rr,
-            }
+                target_temperature = target_temperature or 21
 
-            data = json.dumps(data)
+                data = {
+                    "climatisationMode": climatisation_mode or "comfort",
+                    "targetTemperature": target_temperature,
+                    "targetTemperatureUnit": "celsius",
+                    "climatisationWithoutExternalPower": True,
+                    "climatizationAtUnlock": bool(climatisation_at_unlock),
+                    "windowHeatingEnabled": bool(glass_heating),
+                    "zoneFrontLeftEnabled": bool(seat_fl),
+                    "zoneFrontRightEnabled": bool(seat_fr),
+                    "zoneRearLeftEnabled": bool(seat_rl),
+                    "zoneRearRightEnabled": bool(seat_rr),
+                }
+                data = json.dumps(data)
+            else:
+                _LOGGER.debug(
+                    "No climate settings supplied; starting climatisation with the settings stored in the vehicle."
+                )
+
             headers = {
                 "Authorization": "Bearer " + self._bearer_token_json["access_token"]
             }

--- a/tests/test_climate_start_payload.py
+++ b/tests/test_climate_start_payload.py
@@ -1,0 +1,125 @@
+"""#771: on API level 1 some vehicles reject a settings payload outright, because
+they have no comfort climatisation profile to apply it to. When the caller asks
+for climatisation without supplying any settings, send no body and let the car
+use the settings it already holds, which is what the myAudi app does.
+
+No network: the API layer is replaced with a recorder.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from custom_components.audiconnect.audi_services import AudiService
+
+
+class _RecordingAPI:
+    """Stands in for AudiAPI and records what the service tried to send."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def use_token(self, token) -> None:  # noqa: D102
+        pass
+
+    async def request(self, method, url, headers=None, data=None, **kwargs):
+        self.calls.append(
+            {"method": method, "url": url, "headers": headers, "data": data}
+        )
+        return {"action": {"actionId": "test-action"}}
+
+
+def _service(api_level: int, country: str = "DE") -> tuple[AudiService, _RecordingAPI]:
+    api = _RecordingAPI()
+    service = AudiService(api, country, None, api_level)
+    service._bearer_token_json = {"access_token": "test-token"}
+    service.vwToken = {"access_token": "test-token"}
+
+    async def _succeeded(*args, **kwargs):
+        return None
+
+    # The follow-up poll is a separate concern; this test is about the payload.
+    service.check_request_succeeded = _succeeded
+    return service, api
+
+
+def _start(service: AudiService, **kwargs) -> None:
+    asyncio.run(service.start_climate_control("WAUZZZ00000000000", **kwargs))
+
+
+def test_no_settings_sends_no_body() -> None:
+    # The Q6 e-tron case from #771: nothing supplied, so nothing is imposed.
+    service, api = _service(api_level=1)
+    _start(service)
+
+    assert len(api.calls) == 1
+    assert api.calls[0]["data"] is None
+
+
+def test_supplied_temperature_still_sends_a_body() -> None:
+    service, api = _service(api_level=1)
+    _start(service, temp_c=22)
+
+    body = json.loads(api.calls[0]["data"])
+    assert body["targetTemperature"] == 22
+    assert body["targetTemperatureUnit"] == "celsius"
+
+
+def test_a_single_supplied_setting_is_enough_to_send_a_body() -> None:
+    # Asking for one seat is still asking for something, so the vehicle's own
+    # settings must not silently win.
+    service, api = _service(api_level=1)
+    _start(service, seat_fl=True)
+
+    body = json.loads(api.calls[0]["data"])
+    assert body["zoneFrontLeftEnabled"] is True
+    assert body["zoneFrontRightEnabled"] is False
+
+
+def test_climatisation_mode_defaults_instead_of_serialising_null() -> None:
+    # The service call leaves climatisation_mode unset unless the user picks one,
+    # which used to put a literal null on the wire.
+    service, api = _service(api_level=1)
+    _start(service, temp_c=21)
+
+    body = json.loads(api.calls[0]["data"])
+    assert body["climatisationMode"] == "comfort"
+
+
+def test_explicitly_disabling_everything_still_sends_a_body() -> None:
+    # All-false is a real instruction, not an absence of one.
+    service, api = _service(api_level=1)
+    _start(
+        service,
+        glass_heating=False,
+        seat_fl=False,
+        seat_fr=False,
+        seat_rl=False,
+        seat_rr=False,
+        climatisation_at_unlock=False,
+    )
+
+    body = json.loads(api.calls[0]["data"])
+    assert body["windowHeatingEnabled"] is False
+    assert body["zoneFrontLeftEnabled"] is False
+
+
+def test_api_level_0_zone_settings_are_unchanged_by_missing_values() -> None:
+    # API level 0 has always sent a full payload and must keep doing so; an
+    # unsupplied seat is off, exactly as before. US so the request goes to the
+    # fixed endpoint rather than a looked-up home region.
+    service, api = _service(api_level=0, country="US")
+    _start(service)
+
+    body = json.loads(api.calls[0]["data"])
+    zones = body["action"]["settings"]["climaterElementSettings"]["zoneSettings"][
+        "zoneSetting"
+    ]
+    assert [zone["value"]["isEnabled"] for zone in zones] == [
+        False,
+        False,
+        False,
+        False,
+    ]
+    assert body["action"]["settings"]["targetTemperature"] == 2941


### PR DESCRIPTION
### What this fixes

On API level 1 the integration always sends a full climatisation settings payload. Vehicles without a comfort climatisation profile reject it. The rejection only arrives after the car has synchronised, so Home Assistant reports the action as successful and the error surfaces in the myAudi app instead, which is what makes this one awkward to spot.

Reported in #771 for a Q6 e-tron, with a second reporter in the same thread independently arriving at the same workaround and confirming it works.

### What changed

When the service call supplies no settings at all, send no body and let the vehicle apply the settings it already holds. That is what the myAudi app does on a car with no comfort climatisation profile. Any supplied setting still produces the full payload exactly as before.

Two smaller things came out of the same code path:

- `climatisationMode` was serialised as a literal `null` whenever the service call left it unset, since the value is passed straight through. It now falls back to `comfort`.
- `audi_account.py` no longer substitutes `False` for the unset booleans. Without that, the service layer cannot tell "nothing was asked for" from "everything was explicitly asked to be off". API level 0 is unaffected: its payload is built with an explicit `bool()` conversion and still sends every field.

### Behaviour change

`start_climate_control` called with no parameters previously imposed 21 degrees with all zones off. It now leaves the vehicle's own settings alone. Callers that pass settings see no change.

### Tests

`tests/test_climate_start_payload.py`, six cases: the empty body, a supplied temperature, a single supplied setting, the mode fallback, an explicit all off, and an API level 0 regression guard. Full suite is 10 green and needs no network.

### Verification

I do not have a Q6 e-tron, so this rests on the two independent reports in #771 rather than my own live test. Worth a prerelease check with an affected car before it reaches stable.

### Target branch

Opened against master because beta no longer exists after #820. Happy to retarget as soon as it is back.
