### PR TITLE
fix: back off between login attempts instead of retrying at a fixed interval (#786)

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -21,6 +21,10 @@ _LOGGER = logging.getLogger(__name__)
 MAX_RESPONSE_ATTEMPTS = 10
 REQUEST_STATUS_SLEEP = 5
 
+# Ceiling for the exponential backoff between login attempts, so a larger retry
+# count can never stretch a single login into an unbounded wait.
+MAX_LOGIN_RETRY_DELAY = 60
+
 ACTION_LOCK = "lock"
 ACTION_CLIMATISATION = "climatisation"
 ACTION_CHARGER = "charger"
@@ -133,11 +137,16 @@ class AudiConnectAccount:
                 break
 
             if i < self._connect_retries - 1:
-                _LOGGER.warning(
+                # Back off between attempts. When the Audi service is having a
+                # bad day, hammering it at a fixed interval neither helps us nor
+                # them. The last attempt logs the real error, so the ones in
+                # between stay at debug and don't fill the log on every poll.
+                delay = min(self._connect_delay * 2**i, MAX_LOGIN_RETRY_DELAY)
+                _LOGGER.debug(
                     "LOGIN: Login to Audi service failed, retrying in %s seconds",
-                    self._connect_delay,
+                    delay,
                 )
-                await asyncio.sleep(self._connect_delay)
+                await asyncio.sleep(delay)
 
     async def try_login(self, logError):
         try:

--- a/tests/test_login_backoff.py
+++ b/tests/test_login_backoff.py
@@ -1,0 +1,86 @@
+"""#786: a failing login retried at a fixed interval fills the log and keeps
+hammering a service that is already unhappy. Back off between attempts, and keep
+the attempts in between at debug so only the final failure is reported.
+
+No network: try_login and the sleep are both replaced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from custom_components.audiconnect import audi_connect_account
+from custom_components.audiconnect.audi_connect_account import (
+    MAX_LOGIN_RETRY_DELAY,
+    AudiConnectAccount,
+)
+
+
+def _account(monkeypatch) -> tuple[AudiConnectAccount, list[float]]:
+    account = AudiConnectAccount(
+        session=None, country="DE", spin=None, api_level=1, refresh_token="token"
+    )
+
+    slept: list[float] = []
+
+    async def _sleep(delay):
+        slept.append(delay)
+
+    monkeypatch.setattr(audi_connect_account.asyncio, "sleep", _sleep)
+    return account, slept
+
+
+def test_delay_grows_between_attempts(monkeypatch) -> None:
+    account, slept = _account(monkeypatch)
+
+    async def _always_fails(_log_error):
+        return False
+
+    account.try_login = _always_fails
+    asyncio.run(account.login())
+
+    # Three attempts, so two waits, and the second is longer than the first.
+    assert slept == [10, 20]
+
+
+def test_delay_is_capped(monkeypatch) -> None:
+    account, slept = _account(monkeypatch)
+    account._connect_retries = 8
+
+    async def _always_fails(_log_error):
+        return False
+
+    account.try_login = _always_fails
+    asyncio.run(account.login())
+
+    assert max(slept) == MAX_LOGIN_RETRY_DELAY
+    assert slept[-1] == MAX_LOGIN_RETRY_DELAY
+
+
+def test_no_waiting_once_login_succeeds(monkeypatch) -> None:
+    account, slept = _account(monkeypatch)
+
+    async def _succeeds(_log_error):
+        return True
+
+    account.try_login = _succeeds
+    asyncio.run(account.login())
+
+    assert slept == []
+    assert account._loggedin is True
+
+
+def test_retries_stop_at_the_configured_count(monkeypatch) -> None:
+    account, slept = _account(monkeypatch)
+    attempts: list[bool] = []
+
+    async def _records(log_error):
+        attempts.append(log_error)
+        return False
+
+    account.try_login = _records
+    asyncio.run(account.login())
+
+    # The final attempt is the one allowed to report the error.
+    assert len(attempts) == account._connect_retries
+    assert attempts == [False, False, True]


### PR DESCRIPTION
### What this fixes

Login retries are spaced at a constant ten seconds and each one logs a warning. When the Audi service is having a bad spell, every poll produces the same burst of warnings, and we keep knocking at a fixed rate on a service that is already struggling.

Raised in #786.

### What changed

The wait between attempts now doubles, capped by a new `MAX_LOGIN_RETRY_DELAY` of 60 seconds so a larger retry count can never stretch a single login into an unbounded wait. With the current three attempts that means 10 seconds and then 20, instead of 10 and 10.

The intermediate attempts drop to debug. The final attempt is the one that already reports the real error, so a genuine failure stays exactly as visible as before, while a recoverable hiccup no longer writes three warnings per poll.

### Tests

`tests/test_login_backoff.py`, four cases: the delay growing between attempts, the cap holding with a raised retry count, no waiting at all once a login succeeds, and the attempt count with the final attempt being the one allowed to report. Full suite is 8 green and needs no network.

### Note

This only addresses the retry loop inside a single login. The issue also asks for a disclaimer, which I have left alone since it is a separate call on wording and placement.

### Target branch

Opened against master because beta no longer exists after #820. Happy to retarget as soon as it is back.
