### PR TITLE
fix: log an unknown vehicle action instead of doing nothing

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -208,6 +208,8 @@ class AudiAccount(AudiConnectObserver):
             await self.connection.set_vehicle_window_heating(vin, True)
         elif action == "stop_window_heating":
             await self.connection.set_vehicle_window_heating(vin, False)
+        else:
+            _LOGGER.error("Unknown vehicle action requested: %s", action)
 
     async def start_climate_control(self, vin: str, service: ServiceCall) -> None:
         """Start climate control for a vehicle by VIN."""


### PR DESCRIPTION
Another silent-failure case, in the same family as #821 (all-error payload wiping entities) and #822 (climatisation reported successful while the car rejected it).

`execute_vehicle_action()` dispatches on the action string through an `if`/`elif` chain with **no `else`**. An unrecognised action — a typo in an automation, or an action renamed/removed later — silently does nothing: no command sent, no error, no log, and the service call still reports success.

Add an `else` that logs the unknown action at error level, so a mistyped action is diagnosable instead of vanishing.

```python
elif action == "stop_window_heating":
    await self.connection.set_vehicle_window_heating(vin, False)
else:
    _LOGGER.error("Unknown vehicle action requested: %s", action)
```

*Prepared with AI assistance; reviewed by me.*
