### PR TITLE
fix: surface a failed lock/unlock instead of silently swallowing it

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -346,6 +346,7 @@ class AudiConnectAccount:
                     action="lock" if lock else "unlock", vin=vin
                 ),
             )
+            return False
         finally:
             try:
                 await self.notify(vin, ACTION_LOCK)

--- a/custom_components/audiconnect/lock.py
+++ b/custom_components/audiconnect/lock.py
@@ -7,6 +7,7 @@ from typing import Any
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AudiRuntimeData
@@ -52,12 +53,18 @@ class AudiLock(AudiEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         connection = self.coordinator.account.connection
-        await connection.set_vehicle_lock(self._vehicle.vin, True)
+        if not await connection.set_vehicle_lock(self._vehicle.vin, True):
+            raise HomeAssistantError(
+                "Failed to lock the vehicle; see the log for details"
+            )
         await self.coordinator.async_request_refresh()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         connection = self.coordinator.account.connection
-        await connection.set_vehicle_lock(self._vehicle.vin, False)
+        if not await connection.set_vehicle_lock(self._vehicle.vin, False):
+            raise HomeAssistantError(
+                "Failed to unlock the vehicle; see the log for details"
+            )
         await self.coordinator.async_request_refresh()
 
 


### PR DESCRIPTION
Same silent-failure family as #821 (all-error payload wiping entities) and #822 (climatisation reported successful while the car rejected it) — this is the lock/unlock case.

`set_vehicle_lock()` caught every exception, logged it, and returned `None` — unlike its siblings (`set_vehicle_climatisation`, `set_target_state_of_charge`) which return `False` on failure. The lock entity then ignored the result entirely, so a failed lock/unlock (403, network error, S-PIN rejected) animated the button, refreshed, and showed **nothing**: the only trace was a log line the UI never surfaces.

- `set_vehicle_lock()` now returns `False` on failure, matching the other command methods.
- `AudiLock.async_lock`/`async_unlock` raise `HomeAssistantError` when the command fails, so Home Assistant shows the error to the user instead of a silent no-op.

Scope note: this only surfaces a command the backend **rejects outright**. It doesn't change the separate "accepted but the vehicle didn't act" case (same shape as #822's climate path) — that still has to be read from vehicle state, and is out of scope here.

*Prepared with AI assistance; reviewed by me.*
