### PR TITLE
fix: schedule the reload ourselves on reauth/reconfigure (HA 2026.12)

### DIFF
--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -173,9 +173,7 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
             # Schedule the reload ourselves: async_update_reload_and_abort is
             # deprecated (HA 2026.12) for entries that register an update
             # listener, which this integration does.
-            self.hass.config_entries.async_schedule_reload(
-                self._reauth_entry.entry_id
-            )
+            self.hass.config_entries.async_schedule_reload(self._reauth_entry.entry_id)
             return self.async_update_and_abort(
                 self._reauth_entry,
                 data={
@@ -258,9 +256,7 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
             # device-code reauth only changes the refresh token, which the
             # update listener deliberately ignores, so the reload has to be
             # scheduled here explicitly.
-            self.hass.config_entries.async_schedule_reload(
-                self._reauth_entry.entry_id
-            )
+            self.hass.config_entries.async_schedule_reload(self._reauth_entry.entry_id)
             return self.async_update_and_abort(
                 self._reauth_entry,
                 data={
@@ -315,9 +311,7 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             # Schedule the reload ourselves (see _finish_password_login).
-            self.hass.config_entries.async_schedule_reload(
-                reconfigure_entry.entry_id
-            )
+            self.hass.config_entries.async_schedule_reload(reconfigure_entry.entry_id)
             return self.async_update_and_abort(
                 reconfigure_entry,
                 data_updates={

--- a/custom_components/audiconnect/config_flow.py
+++ b/custom_components/audiconnect/config_flow.py
@@ -170,7 +170,13 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Persist a username/password entry (or update it on reauth)."""
         if self._reauth_entry is not None:
-            return self.async_update_reload_and_abort(
+            # Schedule the reload ourselves: async_update_reload_and_abort is
+            # deprecated (HA 2026.12) for entries that register an update
+            # listener, which this integration does.
+            self.hass.config_entries.async_schedule_reload(
+                self._reauth_entry.entry_id
+            )
+            return self.async_update_and_abort(
                 self._reauth_entry,
                 data={
                     **self._reauth_entry.data,
@@ -248,7 +254,14 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="device_auth_failed")
 
         if self._reauth_entry is not None:
-            return self.async_update_reload_and_abort(
+            # Schedule the reload ourselves (see _finish_password_login). A
+            # device-code reauth only changes the refresh token, which the
+            # update listener deliberately ignores, so the reload has to be
+            # scheduled here explicitly.
+            self.hass.config_entries.async_schedule_reload(
+                self._reauth_entry.entry_id
+            )
+            return self.async_update_and_abort(
                 self._reauth_entry,
                 data={
                     **self._reauth_entry.data,
@@ -301,7 +314,11 @@ class AudiConfigFlow(ConfigFlow, domain=DOMAIN):
         reconfigure_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            return self.async_update_reload_and_abort(
+            # Schedule the reload ourselves (see _finish_password_login).
+            self.hass.config_entries.async_schedule_reload(
+                reconfigure_entry.entry_id
+            )
+            return self.async_update_and_abort(
                 reconfigure_entry,
                 data_updates={
                     CONF_SPIN: user_input.get(CONF_SPIN),


### PR DESCRIPTION
Home Assistant logs this on every reauth/reconfigure, and it will break in **2026.12**:

```
Detected that custom integration 'audiconnect' has an update listener and should use it
for scheduling a reload. This will stop working in Home Assistant 2026.12.0, please create
a bug report at https://github.com/audiconnect/audi_connect_ha/issues
```

It comes from `async_update_reload_and_abort()`: when the entry registers an update listener (this integration does), HA now wants the reload scheduled explicitly, and from 2026.12 that helper will stop reloading. The message also tells users to **open a bug report**, so it generates duplicate issues.

### Fix

Replace the three call sites (password reauth, device reauth, reconfigure) with `async_update_and_abort()` + `async_schedule_reload()` — the replacement HA's own docstring recommends (*"When reloading from an integration it is preferable to call async_schedule_reload"*).

Scheduling the reload explicitly is **required**, not cosmetic: a device-code reauth only changes the refresh token, which the update listener deliberately skips (#798, to avoid reloading on hourly token rotation). Relying on the listener alone would leave a re-authenticated entry stuck in its failed state. The explicit schedule guarantees the reload on all three paths, unchanged data or not.

`async_update_and_abort` keeps the same `reason` defaulting (`reauth_successful` / `reconfigure_successful`) and was added to HA core alongside `async_update_reload_and_abort`, so it introduces no new minimum-version requirement.

### Testing

No automated test: `config_flow` imports `homeassistant.config_entries`, which this repo's harness-free tests don't load, and a full HA test harness would be a heavy new dependency for a three-line change. Verified two ways:

- **By tracing** each path (reauth device / reauth password / reconfigure → reload scheduled; token rotation → still no reload; deprecation → no remaining call to the deprecated helper).
- **On a real EU install** (2.3.1, device-code): applied the change, restarted, ran a reconfigure — reconfigure succeeded, the 49 entities reloaded cleanly, and the `has an update listener` warning no longer appears in the log.

*Prepared with AI assistance; reviewed and tested by me.*
