### PR TITLE
feat: add a Position Last Updated sensor

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -2062,6 +2062,22 @@ class AudiConnectVehicle:
         return self._vehicle.state.get("isMirrorHeatingActive") is not None
 
     @property
+    def position_last_updated(self):
+        """When the vehicle last reported the position, not when HA last polled.
+
+        parkingposition carries its own carCapturedTimestamp and only moves when
+        the car reports a new position, so a location can be hours old while the
+        entity looks current. Exposing the capture time lets an automation decide
+        whether a position is fresh enough to act on.
+        """
+        if self.position_last_updated_supported:
+            return (self._vehicle.state.get("position") or {}).get("timestamp")
+
+    @property
+    def position_last_updated_supported(self):
+        return (self._vehicle.state.get("position") or {}).get("timestamp") is not None
+
+    @property
     def park_time(self):
         if self.park_time_supported:
             return self._vehicle.state.get("vehicleParkingClock")

--- a/custom_components/audiconnect/sensor.py
+++ b/custom_components/audiconnect/sensor.py
@@ -369,6 +369,14 @@ SENSOR_DESCRIPTIONS: tuple[AudiSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
     AudiSensorEntityDescription(
+        key="position_last_updated",
+        attr_key="position_last_updated",
+        name="Position Last Updated",
+        icon="mdi:map-marker-clock",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    AudiSensorEntityDescription(
         key="remaining_climatisation_time",
         attr_key="remaining_climatisation_time",
         name="Remaining Climatisation Time",

--- a/tests/test_position_last_updated.py
+++ b/tests/test_position_last_updated.py
@@ -1,0 +1,95 @@
+"""The position sensor reports a location, but not how old it is.
+
+parkingposition carries its own carCapturedTimestamp and only moves when the car
+reports a new position, so device_tracker can show a confident `home` that is
+hours stale, and nothing in Home Assistant distinguishes that from a live fix.
+These pin the accessor that exposes the capture time, including the case where
+the vehicle omits the timestamp entirely (update_vehicle_position stores None
+for it rather than failing).
+
+    python3 -m pytest phase-audi-charging/tests -q
+
+Exercises the REAL AudiConnectVehicle property, with its state dict populated
+the way update_vehicle_position populates it. The service is never touched by
+this code path, so no HTTP boundary is mocked and the test fails if the property
+is absent or wrong.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+
+from custom_components.audiconnect.audi_connect_account import AudiConnectVehicle
+
+
+class _Stub:
+    """AudiConnectVehicle only reads `vin` from the vehicle at construction and
+    never touches the service for this property, so the real class can be built
+    directly rather than reimplemented in the test."""
+
+    vin = "WAUZZZ00000000000"
+
+
+def _accessor(position):
+    """The REAL AudiConnectVehicle, with its state dict populated the way
+    update_vehicle_position populates it."""
+    v = AudiConnectVehicle(audi_service=None, vehicle=_Stub())
+    if position is not None:
+        v._vehicle.state["position"] = position
+    return v
+
+
+CAPTURED = datetime.datetime(2026, 8, 21, 17, 57, 41, tzinfo=datetime.UTC)
+
+
+def test_reports_the_capture_time():
+    a = _accessor({"latitude": 50.86, "longitude": -0.15, "timestamp": CAPTURED})
+    assert a.position_last_updated_supported is True
+    assert a.position_last_updated == CAPTURED
+
+
+def test_absent_timestamp_is_unsupported_not_an_error():
+    """update_vehicle_position stores timestamp None when the car omits
+    carCapturedTimestamp, so the entity must simply not be offered."""
+    a = _accessor({"latitude": 50.86, "longitude": -0.15, "timestamp": None})
+    assert a.position_last_updated_supported is False
+    assert a.position_last_updated is None
+
+
+def test_no_position_at_all_is_unsupported():
+    """Cars without position support never write the key."""
+    a = _accessor(None)
+    assert a.position_last_updated_supported is False
+    assert a.position_last_updated is None
+
+
+def test_position_present_but_missing_timestamp_key():
+    a = _accessor({"latitude": 50.86, "longitude": -0.15})
+    assert a.position_last_updated_supported is False
+    assert a.position_last_updated is None
+
+
+def test_a_stale_capture_is_still_reported():
+    """The point of the sensor: an old timestamp is a VALUE, not a failure. The
+    caller decides what is too old; the integration must not silently hide it."""
+    stale = datetime.datetime(2026, 8, 14, 6, 0, tzinfo=datetime.UTC)
+    a = _accessor({"latitude": 50.86, "longitude": -0.15, "timestamp": stale})
+    assert a.position_last_updated == stale
+    assert (CAPTURED - a.position_last_updated).days == 7
+
+
+def test_timestamp_is_timezone_aware():
+    """SensorDeviceClass.TIMESTAMP rejects a naive datetime, so a tz-naive value
+    would break the entity at runtime rather than at parse time."""
+    a = _accessor({"latitude": 50.86, "longitude": -0.15, "timestamp": CAPTURED})
+    value = a.position_last_updated
+    assert value.tzinfo is not None
+    assert value.utcoffset() is not None
+
+
+@pytest.mark.parametrize("falsy", [{}, None])
+def test_empty_position_shapes_do_not_raise(falsy):
+    assert _accessor(falsy).position_last_updated is None


### PR DESCRIPTION
## Overview

`device_tracker` reports where the car is, but not how old that reading is. `parkingposition` carries its own `carCapturedTimestamp` and only moves when the car reports a new position, so the tracker can show a confident `home` that is hours stale, and nothing distinguishes it from a live fix. An automation that gates on vehicle location has no way to tell the difference.

`update_vehicle_position` already parses that timestamp and stores it in `state["position"]["timestamp"]`. It was simply never surfaced. This exposes it as a diagnostic timestamp sensor so callers can decide what counts as too old, rather than trusting the position blindly.

Concrete case this came from: a panel gating a persistent setting on "is the car home" acted on a position that turned out to be many hours old. The coordinates were right when captured and wrong to act on later, and nothing in Home Assistant made that visible.

## Changes

Adds `position_last_updated` (plus its `_supported` partner) to `AudiConnectVehicle`, and a `Position Last Updated` sensor with `SensorDeviceClass.TIMESTAMP`, in the diagnostic category.

No new API call and no extra request against the rate limit: the value is already in the response the integration fetches. The entity is only offered when the vehicle actually reports a timestamp, since `update_vehicle_position` stores `None` when `carCapturedTimestamp` is absent.

## Reference

n/a. No linked issue; found while building automations on top of the position data.

## Changelog

Added a Position Last Updated sensor reporting when the vehicle last reported its position.

## Test plan

Automated, `pytest tests/`: 8 tests over the real `AudiConnectVehicle` property, covering a normal capture, an absent timestamp, no position at all, a missing key, a week-old capture, and timezone-awareness (a naive datetime would break `SensorDeviceClass.TIMESTAMP` at runtime). They fail against `master`, so the suite is known to exercise the change.

To verify on a vehicle:

1. Note the current value of `sensor.<vehicle>_position_last_updated`.
   - [ ] It matches when the car last parked, not when Home Assistant last polled.
2. Call `audiconnect.refresh_cloud_data` without moving the car.
   - [ ] The sensor does not change, because the vehicle has not reported a new position.
3. Drive the car and park somewhere new, then refresh.
   - [ ] The sensor advances to the new capture time.
4. On a vehicle that does not report `carCapturedTimestamp`.
   - [ ] The entity is not created, and the other position entities are unaffected.
