### PR TITLE
feat: set the location charging profile target (the value that governs)

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -22,6 +22,8 @@ from .audi_account import (
     SERVICE_REFRESH_VEHICLE_DATA_SCHEMA,
     SERVICE_SET_CHARGE_MODE,
     SERVICE_SET_CHARGE_MODE_SCHEMA,
+    SERVICE_SET_LOCATION_CHARGE_TARGET,
+    SERVICE_SET_LOCATION_CHARGE_TARGET_SCHEMA,
     SERVICE_SET_TARGET_SOC,
     SERVICE_SET_TARGET_SOC_SCHEMA,
     SERVICE_START_AUXILIARY_HEATING,
@@ -247,6 +249,13 @@ def _async_register_services(hass: HomeAssistant) -> None:
         vin, account = result
         await account.start_auxiliary_heating(vin, service)
 
+    async def _handle_set_location_charge_target(service: ServiceCall) -> None:
+        result = _resolve_service_call(hass, service)
+        if result is None:
+            return
+        vin, account = result
+        await account.set_location_charge_target(vin, service)
+
     async def _handle_set_charge_mode(service: ServiceCall) -> None:
         result = _resolve_service_call(hass, service)
         if result is None:
@@ -306,6 +315,13 @@ def _async_register_services(hass: HomeAssistant) -> None:
             SERVICE_START_AUXILIARY_HEATING,
             _handle_start_auxiliary_heating,
             schema=SERVICE_START_AUXILIARY_HEATING_SCHEMA,
+        )
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_LOCATION_CHARGE_TARGET):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_LOCATION_CHARGE_TARGET,
+            _handle_set_location_charge_target,
+            schema=SERVICE_SET_LOCATION_CHARGE_TARGET_SCHEMA,
         )
     if not hass.services.has_service(DOMAIN, SERVICE_SET_CHARGE_MODE):
         hass.services.async_register(
@@ -431,6 +447,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
             SERVICE_START_CLIMATE_CONTROL,
             SERVICE_START_AUXILIARY_HEATING,
             SERVICE_SET_CHARGE_MODE,
+            SERVICE_SET_LOCATION_CHARGE_TARGET,
             SERVICE_SET_TARGET_SOC,
             SERVICE_START_ENGINE,
             SERVICE_STOP_ENGINE,

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -89,7 +89,9 @@ SERVICE_SET_LOCATION_CHARGE_TARGET = "set_location_charge_target"
 SERVICE_SET_LOCATION_CHARGE_TARGET_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Optional(CONF_PROFILE_ID): vol.All(cv.positive_int, vol.Range(min=1, max=10)),
+        vol.Optional(CONF_PROFILE_ID): vol.All(
+            cv.positive_int, vol.Range(min=1, max=10)
+        ),
         vol.Required(CONF_TARGET_SOC): vol.All(
             cv.positive_int, vol.Range(min=20, max=100)
         ),
@@ -274,9 +276,7 @@ class AudiAccount(AudiConnectObserver):
             duration=service.data.get(CONF_DURATION),
         )
 
-    async def set_location_charge_target(
-        self, vin: str, service: ServiceCall
-    ) -> None:
+    async def set_location_charge_target(self, vin: str, service: ServiceCall) -> None:
         """Set a location profile's target SoC, the value that governs charging
         at that place. Omit profile_id to target where the car is parked now."""
         if not await self.connection.set_location_charge_target(

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_REGION,
     CONF_SPIN,
     CONF_CHARGE_MODE,
+    CONF_PROFILE_ID,
     CONF_TARGET_SOC,
     CONF_UPDATE_SLEEP,
     CONF_USERNAME,
@@ -81,6 +82,17 @@ SERVICE_START_AUXILIARY_HEATING_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DEVICE_ID): cv.string,
         vol.Optional(CONF_DURATION): cv.positive_int,
+    }
+)
+
+SERVICE_SET_LOCATION_CHARGE_TARGET = "set_location_charge_target"
+SERVICE_SET_LOCATION_CHARGE_TARGET_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Optional(CONF_PROFILE_ID): vol.All(cv.positive_int, vol.Range(min=1, max=10)),
+        vol.Required(CONF_TARGET_SOC): vol.All(
+            cv.positive_int, vol.Range(min=20, max=100)
+        ),
     }
 )
 
@@ -262,6 +274,21 @@ class AudiAccount(AudiConnectObserver):
             duration=service.data.get(CONF_DURATION),
         )
 
+    async def set_location_charge_target(
+        self, vin: str, service: ServiceCall
+    ) -> None:
+        """Set a location profile's target SoC, the value that governs charging
+        at that place. Omit profile_id to target where the car is parked now."""
+        if not await self.connection.set_location_charge_target(
+            vin.lower(),
+            service.data.get(CONF_PROFILE_ID),
+            service.data.get(CONF_TARGET_SOC),
+        ):
+            raise HomeAssistantError(
+                f"Audi Connect could not set the location charge target for {vin}. "
+                "See the log for the underlying error."
+            )
+
     async def set_charge_mode(self, vin: str, service: ServiceCall) -> None:
         """Set which mode the car charges in, without starting or stopping one."""
         await self.connection.set_charge_mode(
@@ -328,6 +355,8 @@ __all__ = [
     "SERVICE_REFRESH_VEHICLE_DATA",
     "SERVICE_REFRESH_VEHICLE_DATA_SCHEMA",
     "SERVICE_SET_CHARGE_MODE",
+    "SERVICE_SET_LOCATION_CHARGE_TARGET",
+    "SERVICE_SET_LOCATION_CHARGE_TARGET_SCHEMA",
     "SERVICE_SET_CHARGE_MODE_SCHEMA",
     "SERVICE_SET_TARGET_SOC",
     "SERVICE_SET_TARGET_SOC_SCHEMA",

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -355,9 +355,7 @@ class AudiConnectAccount:
                     "Cloud refresh failed after lock/unlock for %s: %s", vin, ex
                 )
 
-    async def set_location_charge_target(
-        self, vin: str, profile_id, target_soc: int
-    ):
+    async def set_location_charge_target(self, vin: str, profile_id, target_soc: int):
         """Set a location charging profile's target SoC (the governing value)."""
         if not self._loggedin:
             await self.login()
@@ -366,7 +364,9 @@ class AudiConnectAccount:
         try:
             _LOGGER.debug(
                 "Setting location charge target to %d%% (profile %s) for %s",
-                target_soc, profile_id, vin,
+                target_soc,
+                profile_id,
+                vin,
             )
             await self._audi_service.set_location_charge_target(
                 vin, profile_id, target_soc

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -355,6 +355,30 @@ class AudiConnectAccount:
                     "Cloud refresh failed after lock/unlock for %s: %s", vin, ex
                 )
 
+    async def set_location_charge_target(
+        self, vin: str, profile_id, target_soc: int
+    ):
+        """Set a location charging profile's target SoC (the governing value)."""
+        if not self._loggedin:
+            await self.login()
+        if not self._loggedin:
+            return False
+        try:
+            _LOGGER.debug(
+                "Setting location charge target to %d%% (profile %s) for %s",
+                target_soc, profile_id, vin,
+            )
+            await self._audi_service.set_location_charge_target(
+                vin, profile_id, target_soc
+            )
+            return True
+        except Exception as exception:
+            log_exception(
+                exception,
+                f"Unable to set location charge target for vehicle {vin}",
+            )
+            return False
+
     async def set_charge_mode(self, vin: str, mode: str):
         """Set the preferred charge mode (manual or timer)."""
         if not self._loggedin:

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -30,9 +30,7 @@ CHARGING_CONFIRM_ATTEMPTS = 3
 CHARGING_CONFIRM_SLEEP = 5
 
 
-def build_profile_update(
-    value: dict, profile_id, target_soc: int
-) -> tuple[int, dict]:
+def build_profile_update(value: dict, profile_id, target_soc: int) -> tuple[int, dict]:
     """Pure read-modify-write core for a location charging profile.
 
     `value` is chargingProfiles.chargingProfilesStatus.value as the car reports

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -29,6 +29,38 @@ REQUEST_STATUS_SLEEP = 10
 CHARGING_CONFIRM_ATTEMPTS = 3
 CHARGING_CONFIRM_SLEEP = 5
 
+
+def build_profile_update(
+    value: dict, profile_id, target_soc: int
+) -> tuple[int, dict]:
+    """Pure read-modify-write core for a location charging profile.
+
+    `value` is chargingProfiles.chargingProfilesStatus.value as the car reports
+    it. Returns (resolved_profile_id, put_body) where put_body is exactly what
+    goes on the wire: {"profile": <the whole profile, one field changed>}.
+
+    Kept pure and module-level so the field-preservation and profile-selection
+    logic is testable against a real payload without standing up the service.
+    """
+    if not (20 <= target_soc <= 100):
+        raise ValueError("Target state of charge must be between 20 and 100 percent")
+
+    profiles = (value or {}).get("profiles") or []
+    if profile_id is None:
+        profile_id = (value or {}).get("vehiclePositionedInProfileID")
+    profile = next((p for p in profiles if p.get("id") == profile_id), None)
+    if profile is None:
+        present = [p.get("id") for p in profiles]
+        raise ValueError(
+            f"No charging profile with id {profile_id} (present: {present})"
+        )
+
+    # Change exactly one field; round-trip the rest, position included.
+    updated = dict(profile)
+    updated["targetSOC_pct"] = target_soc
+    return profile_id, {"profile": updated}
+
+
 SUCCEEDED = "succeeded"
 FAILED = "failed"
 REQUEST_SUCCESSFUL = "request_successful"
@@ -643,6 +675,68 @@ class AudiService:
         #     FAILED,
         #     "action.actionState",
         # )
+
+    async def get_charging_profiles_raw(self, vin: str) -> dict:
+        """Fetch just the chargingProfiles job, unparsed.
+
+        The write is a read-modify-write and the BFF replaces the whole profile,
+        so we need the profile exactly as the car reports it, not the scrubbed
+        summary the sensor keeps.
+        """
+        self._api.use_token(self._bearer_token_json)
+        return await self._api.get(
+            self.__get_cariad_url_for_vin(
+                vin, "selectivestatus?jobs={jobs}", jobs="chargingProfiles"
+            )
+        )
+
+    async def set_location_charge_target(
+        self, vin: str, profile_id: int | None, target_soc: int
+    ) -> None:
+        """Set a location charging profile's target SoC.
+
+        This is the value that actually governs where a charge stops at a
+        location; the global charging/settings target does not (upstream #722).
+
+        Endpoint, verb and body shape are from the myAudi app 4.30:
+            PUT charging/profiles   body {"profile": {<whole profile>}}
+        The PUT replaces the entire profile, so this reads the current one,
+        changes only targetSOC_pct, and sends everything else back unchanged.
+        Never invent or drop a field.
+
+        profile_id None targets the profile the car is currently parked in.
+        """
+        raw = await self.get_charging_profiles_raw(vin)
+        value = get_attr(raw, "chargingProfiles.chargingProfilesStatus.value")
+        profile_id, put_body = build_profile_update(value, profile_id, target_soc)
+
+        headers = {
+            "Authorization": "Bearer " + self._bearer_token_json["access_token"],
+            "Content-Type": "application/json",
+        }
+        try:
+            res = await self._api.request(
+                "PUT",
+                self.__get_cariad_url_for_vin(vin, "charging/profiles"),
+                headers=headers,
+                data=json.dumps(put_body),
+            )
+        except ClientResponseError as err:
+            if err.status == 204:
+                res = None
+            else:
+                raise
+
+        request_id = get_attr(res, "data.requestID") if isinstance(res, dict) else None
+        if request_id is None:
+            _LOGGER.debug(
+                "Location charge target for %s accepted with no request id to confirm",
+                vin,
+            )
+            return
+        await self._confirm_charging_command(
+            vin, f"profile {profile_id} target {target_soc}%", request_id
+        )
 
     async def set_target_state_of_charge(self, vin: str, target_soc: int):
         """Set the target state of charge (battery percentage)."""

--- a/custom_components/audiconnect/const.py
+++ b/custom_components/audiconnect/const.py
@@ -25,6 +25,7 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_API_LEVEL = "api_level"
 CONF_DURATION = "duration"
 CONF_CHARGE_MODE = "charge_mode"
+CONF_PROFILE_ID = "profile_id"
 CONF_TARGET_SOC = "target_soc"
 
 MIN_UPDATE_INTERVAL = 15
@@ -123,6 +124,7 @@ __all__ = [
     "CONF_SCAN_INTERVAL",
     "CONF_SPIN",
     "CONF_CHARGE_MODE",
+    "CONF_PROFILE_ID",
     "CONF_TARGET_SOC",
     "CONF_UPDATE_SLEEP",
     "CONF_USERNAME",

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -93,6 +93,30 @@ start_auxiliary_heating:
           step: 10
           unit_of_measurement: "minutes"
 
+set_location_charge_target:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: audiconnect
+    profile_id:
+      example: 1
+      selector:
+        number:
+          min: 1
+          max: 10
+          step: 1
+    target_soc:
+      required: true
+      example: 80
+      selector:
+        number:
+          min: 20
+          max: 100
+          step: 5
+          unit_of_measurement: "%"
+
 set_charge_mode:
   fields:
     device_id:

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -194,6 +194,24 @@
         }
       }
     },
+    "set_location_charge_target": {
+      "name": "Set Location Charge Target",
+      "description": "Set a location charging profile's target state of charge. This is the value that actually governs where a charge stops at that location, unlike the global target. It is a persistent setting: it applies to every charge at that location until changed.",
+      "fields": {
+        "device_id": {
+          "name": "Vehicle",
+          "description": "The Audi vehicle."
+        },
+        "profile_id": {
+          "name": "Profile",
+          "description": "The charging profile id to change. Leave empty to change whichever profile the car is currently parked in."
+        },
+        "target_soc": {
+          "name": "Target State of Charge",
+          "description": "Target charge level for this location, 20-100% in steps of 5."
+        }
+      }
+    },
     "set_charge_mode": {
       "name": "Set Charge Mode",
       "description": "Set which mode the vehicle charges in. This is a preference and does not start or stop a charge in progress.",

--- a/custom_components/audiconnect/translations/en.json
+++ b/custom_components/audiconnect/translations/en.json
@@ -194,6 +194,24 @@
         }
       }
     },
+    "set_location_charge_target": {
+      "name": "Set Location Charge Target",
+      "description": "Set a location charging profile's target state of charge. This is the value that actually governs where a charge stops at that location, unlike the global target. It is a persistent setting: it applies to every charge at that location until changed.",
+      "fields": {
+        "device_id": {
+          "name": "Vehicle",
+          "description": "The Audi vehicle."
+        },
+        "profile_id": {
+          "name": "Profile",
+          "description": "The charging profile id to change. Leave empty to change whichever profile the car is currently parked in."
+        },
+        "target_soc": {
+          "name": "Target State of Charge",
+          "description": "Target charge level for this location, 20-100% in steps of 5."
+        }
+      }
+    },
     "set_charge_mode": {
       "name": "Set Charge Mode",
       "description": "Set which mode the vehicle charges in. This is a preference and does not start or stop a charge in progress.",

--- a/tests/test_profile_write.py
+++ b/tests/test_profile_write.py
@@ -1,0 +1,117 @@
+"""#722: set the location charging profile's target SoC — the value that
+actually governs where a charge stops at that location. The write is a
+read-modify-write (the CARIAD BFF PUT replaces the whole profile), so the one
+field that must change has to change and every other field, the home-location
+coordinates included, must survive untouched. That is what these pin, against a
+real profile payload captured from the car.
+
+The pure core (build_profile_update) is tested, so no HTTP boundary is mocked
+and there is no mock-verifies-mock.
+
+Composes with the pytest harness from #815 (no network).
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from custom_components.audiconnect.audi_services import build_profile_update
+
+from tests.fixture_q8_etron import PAYLOAD
+
+
+@pytest.fixture
+def value():
+    """chargingProfiles.chargingProfilesStatus.value, as the car reports it."""
+    return copy.deepcopy(
+        PAYLOAD["chargingProfiles"]["chargingProfilesStatus"]["value"]
+    )
+
+
+# --- the change itself ------------------------------------------------------------
+
+
+def test_changes_only_the_target(value):
+    original = copy.deepcopy(value["profiles"][0])  # Home, id 1
+    resolved_id, body = build_profile_update(value, 1, 65)
+
+    sent = body["profile"]
+    assert resolved_id == 1
+    assert sent["targetSOC_pct"] == 65
+    # every OTHER field is byte-for-byte what the car reported
+    for key in original:
+        if key != "targetSOC_pct":
+            assert sent[key] == original[key], f"{key} was altered"
+
+
+def test_position_is_preserved(value):
+    """position binds the profile to a location; dropping it would unbind it."""
+    original_pos = value["profiles"][0]["position"]
+    _, body = build_profile_update(value, 1, 70)
+    assert body["profile"]["position"] == original_pos
+    assert "position" in body["profile"]
+
+
+def test_body_is_a_single_wrapped_profile(value):
+    """The Audi PUT wraps ONE profile under `profile`, not the list."""
+    _, body = build_profile_update(value, 1, 55)
+    assert set(body) == {"profile"}
+    assert isinstance(body["profile"], dict)
+    assert body["profile"]["id"] == 1
+
+
+def test_no_extra_or_missing_keys(value):
+    """RMW must not invent a field (e.g. maxChargingCurrent this car omits) nor
+    drop one. The key set is exactly what came back."""
+    original_keys = set(value["profiles"][0])
+    _, body = build_profile_update(value, 1, 60)
+    assert set(body["profile"]) == original_keys
+
+
+# --- profile selection ------------------------------------------------------------
+
+
+def test_selects_by_id(value):
+    _, body = build_profile_update(value, 2, 80)
+    assert body["profile"]["id"] == 2
+    assert body["profile"]["name"] == "Work"
+    assert body["profile"]["targetSOC_pct"] == 80
+
+
+def test_none_targets_the_parked_profile(value):
+    """profile_id None uses vehiclePositionedInProfileID (1 here)."""
+    assert value["vehiclePositionedInProfileID"] == 1
+    resolved_id, body = build_profile_update(value, None, 75)
+    assert resolved_id == 1
+    assert body["profile"]["id"] == 1
+    assert body["profile"]["targetSOC_pct"] == 75
+
+
+def test_unknown_profile_id_raises(value):
+    with pytest.raises(ValueError, match="No charging profile with id 99"):
+        build_profile_update(value, 99, 80)
+
+
+# --- validation -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [0, 10, 19, 101, 105])
+def test_target_out_of_range_raises(value, bad):
+    with pytest.raises(ValueError, match="between 20 and 100"):
+        build_profile_update(value, 1, bad)
+
+
+@pytest.mark.parametrize("ok", [20, 55, 65, 100])
+def test_target_in_range_accepted(value, ok):
+    _, body = build_profile_update(value, 1, ok)
+    assert body["profile"]["targetSOC_pct"] == ok
+
+
+def test_source_value_is_not_mutated(value):
+    """The helper must not edit the fetched payload in place; only the copy that
+    goes on the wire carries the new value."""
+    before = copy.deepcopy(value)
+    build_profile_update(value, 1, 65)
+    assert value == before

--- a/tests/test_profile_write.py
+++ b/tests/test_profile_write.py
@@ -25,9 +25,7 @@ from tests.fixture_q8_etron import PAYLOAD
 @pytest.fixture
 def value():
     """chargingProfiles.chargingProfilesStatus.value, as the car reports it."""
-    return copy.deepcopy(
-        PAYLOAD["chargingProfiles"]["chargingProfilesStatus"]["value"]
-    )
+    return copy.deepcopy(PAYLOAD["chargingProfiles"]["chargingProfilesStatus"]["value"])
 
 
 # --- the change itself ------------------------------------------------------------


### PR DESCRIPTION
## Overview

Follow-up to #834, which exposed the location charging profile but could only read its target SoC. This adds the write. It is the value that actually governs where a charge stops at a location, unlike the global `charging/settings` target (#722).

`PUT charging/profiles` replaces the whole profile, so the service reads the current one, changes only `targetSOC_pct`, and sends the rest back unchanged.

## Changes

New service `set_location_charge_target`: `device_id`, `target_soc` (20-100, step 5), optional `profile_id`. Omit `profile_id` to write whichever profile the car is parked in; pass one to write a specific profile regardless of where the car is.

## Reference

Fixes #722. Builds on #834's `_confirm_charging_command`.

## Changelog

Added a Set Location Charge Target service to set the charging profile target for a location, which is the value the car actually charges to there.

## Test plan

17 tests over a real captured profile payload; they fail against `dev`.

1. Note `sensor.<vehicle>_active_charging_profile_target_soc` and the global `sensor.<vehicle>_target_state_of_charge`.
2. Call `set_location_charge_target` with a `target_soc` different from both, no `profile_id`.
   - [ ] The profile sensor changes once the car reports.
   - [ ] The global target is unchanged.
3. Call it again with an explicit `profile_id` for a profile the car is not parked in.
   - [ ] That profile changes, the parked one does not.

The profile sensor can lag while the car wakes, so judge step 2 once the car has reported rather than immediately.
