### PR TITLE
fix: only prompt reauth when a refresh is rejected with invalid_grant (#840)

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -10,7 +10,7 @@ import re
 import uuid
 from datetime import datetime, timedelta, UTC
 from hashlib import sha256, sha512
-from typing import Any
+from typing import Any, NoReturn
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from aiohttp import ClientResponseError
@@ -74,6 +74,35 @@ _LOGGER = logging.getLogger(__name__)
 
 class AudiAuthError(Exception):
     """Raised when authorization is missing or a token has been rejected."""
+
+
+class AudiTokenRefreshError(Exception):
+    """Raised when a token refresh is rejected for a reason re-authenticating
+    cannot fix — e.g. ``invalid_client`` (the client_id is fixed in code, so a
+    reauth reuses the same client), or a transient / malformed response. It is
+    treated as a retryable update failure rather than escalated to reauth.
+    """
+
+
+# OAuth errors on a refresh exchange that genuinely need the user to sign in
+# again: the refresh token itself is rejected, and only a fresh grant can fix
+# it. Everything else — invalid_client, a transient blip, a malformed body — is
+# retried instead of raising an un-actionable reauth prompt. Listing the hard
+# failures (rather than the transient ones) means an unknown code degrades to a
+# retry, which is the harmless direction.
+_REFRESH_REAUTH_ERRORS = frozenset({"invalid_grant"})
+
+
+def _raise_refresh_rejected(context: str, parsed: dict, raw: str) -> NoReturn:
+    """Raise for a refresh-token exchange that returned no access token.
+
+    ``invalid_grant`` → AudiAuthError (reauth genuinely needed); anything else →
+    AudiTokenRefreshError (retryable, no reauth prompt).
+    """
+    detail = str(parsed.get("error", raw[:200]))
+    if parsed.get("error") in _REFRESH_REAUTH_ERRORS:
+        raise AudiAuthError(f"{context}: {detail}")
+    raise AudiTokenRefreshError(f"{context}: {detail}")
 
 
 def _to_absolute(absolute_url: str, relative_url: str) -> str:
@@ -1318,9 +1347,8 @@ class AudiService:
             )
             refreshed = json.loads(bearer_token_rsptxt)
             if "access_token" not in refreshed:
-                raise AudiAuthError(
-                    "IDK refresh rejected: "
-                    + str(refreshed.get("error", bearer_token_rsptxt[:200]))
+                _raise_refresh_rejected(
+                    "IDK refresh rejected", refreshed, bearer_token_rsptxt
                 )
             self._bearer_token_json = refreshed
 
@@ -1721,9 +1749,7 @@ class AudiService:
         )
         result = json.loads(rsptxt)
         if "access_token" not in result:
-            raise AudiAuthError(
-                "Token refresh rejected: " + str(result.get("error", rsptxt[:200]))
-            )
+            _raise_refresh_rejected("Token refresh rejected", result, rsptxt)
         self._bearer_token_json = result
         await self._finalize_session()
         return self._bearer_token_json.get("refresh_token", refresh_token)
@@ -1891,4 +1917,4 @@ class AudiService:
         return sha512(b).hexdigest().upper()
 
 
-__all__ = ["AudiService"]
+__all__ = ["AudiAuthError", "AudiService", "AudiTokenRefreshError"]

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -97,9 +97,11 @@ def _raise_refresh_rejected(context: str, parsed: dict, raw: str) -> NoReturn:
     """Raise for a refresh-token exchange that returned no access token.
 
     ``invalid_grant`` → AudiAuthError (reauth genuinely needed); anything else →
-    AudiTokenRefreshError (retryable, no reauth prompt).
+    AudiTokenRefreshError (retryable, no reauth prompt). Used for both the IDK
+    refresh and the mbboauth refresh, so it prefers ``error_description`` (which
+    mbboauth returns) for the message while classifying on ``error``.
     """
-    detail = str(parsed.get("error", raw[:200]))
+    detail = str(parsed.get("error_description") or parsed.get("error") or raw[:200])
     if parsed.get("error") in _REFRESH_REAUTH_ERRORS:
         raise AudiAuthError(f"{context}: {detail}")
     raise AudiTokenRefreshError(f"{context}: {detail}")
@@ -1314,7 +1316,14 @@ class AudiService:
                     rsp_wtxt=True,
                 )
                 # this code is the old "vwToken"
-                self.vwToken = json.loads(mbboauth_refresh_rsptxt)
+                refreshed = json.loads(mbboauth_refresh_rsptxt)
+                if "access_token" not in refreshed:
+                    _raise_refresh_rejected(
+                        "mbboauth refresh rejected",
+                        refreshed,
+                        mbboauth_refresh_rsptxt,
+                    )
+                self.vwToken = refreshed
                 # If a new refresh_token is provided, save it for further refreshes
                 if "refresh_token" in self.vwToken:
                     self.mbboauthToken["refresh_token"] = self.vwToken["refresh_token"]
@@ -1900,7 +1909,12 @@ class AudiService:
                 rsp_wtxt=True,
             )
             # this code is the old "vwToken"
-            self.vwToken = json.loads(mbboauth_refresh_rsptxt)
+            refreshed = json.loads(mbboauth_refresh_rsptxt)
+            if "access_token" not in refreshed:
+                _raise_refresh_rejected(
+                    "mbboauth refresh rejected", refreshed, mbboauth_refresh_rsptxt
+                )
+            self.vwToken = refreshed
         else:
             _LOGGER.debug(
                 "mbboauth: no refresh_token in auth response, using auth token directly as vwToken"

--- a/tests/test_refresh_reject_classification.py
+++ b/tests/test_refresh_reject_classification.py
@@ -20,8 +20,14 @@ from custom_components.audiconnect.audi_services import (
 
 def test_invalid_grant_needs_reauth() -> None:
     # The refresh token itself is rejected -> only a fresh sign-in fixes it.
+    # Classification is on ``error`` even when an mbboauth-style
+    # ``error_description`` is also present.
     with pytest.raises(AudiAuthError):
-        _raise_refresh_rejected("IDK refresh rejected", {"error": "invalid_grant"}, "")
+        _raise_refresh_rejected(
+            "mbboauth refresh rejected",
+            {"error": "invalid_grant", "error_description": "token expired"},
+            "",
+        )
 
 
 @pytest.mark.parametrize(
@@ -30,6 +36,7 @@ def test_invalid_grant_needs_reauth() -> None:
         {"error": "invalid_client"},  # client-level: reauth reuses the same client
         {"error": "server_error"},  # transient VW-side blip
         {"error": "temporarily_unavailable"},
+        {"error_description": "mbboauth said no"},  # mbboauth-style, no ``error``
         {},  # malformed / no error field
     ],
 )
@@ -37,6 +44,17 @@ def test_everything_else_is_retryable(parsed: dict) -> None:
     # Unknown / non-grant errors degrade to a retry, never a reauth prompt.
     with pytest.raises(AudiTokenRefreshError):
         _raise_refresh_rejected("IDK refresh rejected", parsed, "{}")
+
+
+def test_message_prefers_error_description() -> None:
+    # mbboauth returns error_description; keep it in the message rather than the
+    # bare error code, matching the guard just above the refresh site.
+    with pytest.raises(AudiTokenRefreshError, match="human readable detail"):
+        _raise_refresh_rejected(
+            "mbboauth refresh rejected",
+            {"error": "invalid_client", "error_description": "human readable detail"},
+            "",
+        )
 
 
 def test_retryable_is_not_an_auth_error() -> None:

--- a/tests/test_refresh_reject_classification.py
+++ b/tests/test_refresh_reject_classification.py
@@ -1,0 +1,45 @@
+"""#840: a rejected IDK refresh should only prompt a reauth when the refresh
+token itself is dead (``invalid_grant``). Anything else — ``invalid_client``
+(the client_id is fixed in code, so a reauth can't help), a transient blip, a
+malformed body — must degrade to a retryable error instead of an un-actionable
+reauth prompt.
+
+No network: the classifier is a pure function over the parsed token response.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.audiconnect.audi_services import (
+    AudiAuthError,
+    AudiTokenRefreshError,
+    _raise_refresh_rejected,
+)
+
+
+def test_invalid_grant_needs_reauth() -> None:
+    # The refresh token itself is rejected -> only a fresh sign-in fixes it.
+    with pytest.raises(AudiAuthError):
+        _raise_refresh_rejected("IDK refresh rejected", {"error": "invalid_grant"}, "")
+
+
+@pytest.mark.parametrize(
+    "parsed",
+    [
+        {"error": "invalid_client"},  # client-level: reauth reuses the same client
+        {"error": "server_error"},  # transient VW-side blip
+        {"error": "temporarily_unavailable"},
+        {},  # malformed / no error field
+    ],
+)
+def test_everything_else_is_retryable(parsed: dict) -> None:
+    # Unknown / non-grant errors degrade to a retry, never a reauth prompt.
+    with pytest.raises(AudiTokenRefreshError):
+        _raise_refresh_rejected("IDK refresh rejected", parsed, "{}")
+
+
+def test_retryable_is_not_an_auth_error() -> None:
+    # AudiTokenRefreshError must not be an AudiAuthError subclass, or the
+    # async_refresh_data handler would still escalate it to reauth.
+    assert not issubclass(AudiTokenRefreshError, AudiAuthError)


### PR DESCRIPTION
Addresses #840.

A rejected IDK refresh raised the same `AudiAuthError` regardless of the OAuth error, and `async_refresh_data` escalates every `AudiAuthError` to `ConfigEntryAuthFailed`. So a transient VW blip or an `invalid_client` — which a reauth **cannot** fix, since the `client_id` is fixed in code — produced an un-actionable reauth prompt for a problem that clears itself.

### Fix

Following the inverse-rule shape @its-me-prash suggested on the issue — list the **hard** failures, not the transient ones — scoped to the refresh exchange:

- **`invalid_grant`** (the refresh token itself is dead) → `AudiAuthError` → reauth. Unchanged.
- **everything else** (`invalid_client`, a transient body, a malformed response) → a new retryable `AudiTokenRefreshError`, which the coordinator surfaces as `UpdateFailed` and retries next cycle (bounded by the existing login backoff). An unknown code degrades to a retry — the harmless direction.

Applied at both refresh points (`login_with_refresh_token` and the periodic IDK refresh).

| refresh error | before | after |
| --- | --- | --- |
| `invalid_grant` | reauth prompt | reauth prompt |
| **`invalid_client`** | **reauth prompt (can't help)** | **retry** |
| transient / malformed | reauth prompt | retry |

### Scope

`invalid_grant` is the only hard failure that surfaces at a *refresh* exchange; the other user-actionable reasons (T&C, consent, 2FA, unfinished portal, bad credentials) surface at the initial login / device approval. Extending the same inverse rule across the whole login path is a sensible follow-up. The twin symptom in #840 — a `401` on an MBB action from an expired `vwToken` with no re-mint/retry — is also left for a follow-up.

### Testing

Unit-tested (`tests/test_refresh_reject_classification.py`): `invalid_grant` → `AudiAuthError`; `invalid_client` / `server_error` / malformed → `AudiTokenRefreshError`; and the retryable error is not an `AudiAuthError` subclass (or `async_refresh_data` would still escalate it). `audi_services` has no Home Assistant import, so this runs in the existing harness-free test setup.

*Prepared with AI assistance; reviewed by me.*
