### PR TITLE
fix: never route to the vwautocloud home region host (#829)

### DIFF
--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -24,6 +24,12 @@ from .util import get_attr, to_byte_array
 MAX_RESPONSE_ATTEMPTS = 10
 REQUEST_STATUS_SLEEP = 10
 
+# The home-region lookup can return a ha-5a.prd.<region>.vwg.vwautocloud.net base
+# URI. That host does not present a usable certificate chain, so every call routed
+# there dies with CERTIFICATE_VERIFY_FAILED. Anything containing this is discarded
+# in favour of the static default.
+UNUSABLE_HOME_REGION_HOST = "vwautocloud"
+
 # Charging start/stop confirmation. Kept short because each poll spends one
 # call from the metered daily allowance and blocks the service call.
 CHARGING_CONFIRM_ATTEMPTS = 3
@@ -356,7 +362,20 @@ class AudiService:
                 and res["homeRegion"]["baseUri"].get("content") is not None
             ):
                 uri = res["homeRegion"]["baseUri"]["content"]
-                if uri != "https://mal-1a.prd.ece.vwg-connect.com/api":
+                if UNUSABLE_HOME_REGION_HOST in uri:
+                    # The endpoint hands back ha-5a.prd.<region>.vwg.vwautocloud.net,
+                    # which does not serve a usable certificate chain and fails with
+                    # CERTIFICATE_VERIFY_FAILED. The static default above already
+                    # works, so keep it. The guard at the top of this method covers
+                    # the same host for non-US accounts on API level 1; this covers
+                    # every other combination, which is how US accounts (#829) and
+                    # API level 0 accounts in Europe still reached it.
+                    _LOGGER.debug(
+                        "HOME REGION: ignoring unusable base URI %s, keeping %s",
+                        uri,
+                        self._homeRegion[vin],
+                    )
+                elif uri != "https://mal-1a.prd.ece.vwg-connect.com/api":
                     self._homeRegionSetter[vin] = uri.split("/api")[0]
                     self._homeRegion[vin] = self._homeRegionSetter[vin].replace(
                         "mal-", "fal-"

--- a/tests/test_home_region_fallback.py
+++ b/tests/test_home_region_fallback.py
@@ -1,0 +1,74 @@
+"""#829: the home-region lookup can return a ha-5a.prd.<region>.vwg.vwautocloud.net
+base URI, which fails with CERTIFICATE_VERIFY_FAILED. It has to be discarded in
+favour of the static default rather than routed to.
+
+The existing guard only covers non-US accounts on API level 1, which is why US
+accounts (#829) and API level 0 accounts in Europe still reached that host.
+
+No network: the API layer is replaced with a stub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from custom_components.audiconnect.audi_services import AudiService
+
+VIN = "WAUZZZ00000000000"
+
+
+class _StubAPI:
+    """Returns a canned homeRegion response."""
+
+    def __init__(self, base_uri: str | None) -> None:
+        self._base_uri = base_uri
+
+    def use_token(self, token) -> None:
+        pass
+
+    async def get(self, url):
+        if self._base_uri is None:
+            raise RuntimeError("home region lookup unavailable")
+        return {"homeRegion": {"baseUri": {"content": self._base_uri}}}
+
+
+def _resolve(base_uri: str | None, country: str, api_level: int) -> tuple[str, str]:
+    api = _StubAPI(base_uri)
+    service = AudiService(api, country, None, api_level)
+    service.vwToken = {"access_token": "test-token"}
+    asyncio.run(service._fill_home_region(VIN))
+    return service._homeRegion[VIN], service._homeRegionSetter[VIN]
+
+
+def test_us_account_does_not_route_to_vwautocloud() -> None:
+    # The reported case: a US account fails the "not US" half of the old guard.
+    region, setter = _resolve("https://ha-5a.prd.nar.vwg.vwautocloud.net/api", "US", 1)
+    assert "vwautocloud" not in region
+    assert "vwautocloud" not in setter
+
+
+def test_api_level_0_in_europe_does_not_route_to_vwautocloud() -> None:
+    # The other half: an API level 0 account in Europe fails the "level 1" half.
+    region, setter = _resolve("https://ha-5a.prd.eu.vwg.vwautocloud.net/api", "DE", 0)
+    assert "vwautocloud" not in region
+    assert "vwautocloud" not in setter
+
+
+def test_a_usable_base_uri_is_still_adopted() -> None:
+    # The lookup is not disabled, only the known-bad host is refused.
+    region, setter = _resolve("https://mal-3a.prd.eu.dp.vwg-connect.com/api", "US", 0)
+    assert setter == "https://mal-3a.prd.eu.dp.vwg-connect.com"
+    assert region == "https://fal-3a.prd.eu.dp.vwg-connect.com"
+
+
+def test_lookup_failure_leaves_the_default_in_place() -> None:
+    region, setter = _resolve(None, "US", 0)
+    assert region == "https://msg.volkswagen.de"
+    assert setter == "https://mal-1a.prd.ece.vwg-connect.com"
+
+
+def test_non_us_api_level_1_keeps_its_existing_shortcut() -> None:
+    # Unchanged behaviour: that path returns before the lookup happens at all.
+    region, setter = _resolve("https://ha-5a.prd.eu.vwg.vwautocloud.net/api", "DE", 1)
+    assert region == "https://mal-3a.prd.eu.dp.vwg-connect.com"
+    assert setter == "https://mal-3a.prd.eu.dp.vwg-connect.com"


### PR DESCRIPTION
### What this fixes

The home-region lookup can return a `ha-5a.prd.<region>.vwg.vwautocloud.net` base URI. That host does not present a usable certificate chain, so anything routed there fails with `CERTIFICATE_VERIFY_FAILED`.

`_fill_home_region` already knew about this. Its comment says the endpoint returns that host and that it is not a valid endpoint, which is why the region is set statically instead. But the guard reads:

```python
if self._country.upper() != "US" and self._api_level == 1:
```

so it only applies to non-US accounts on API level 1. Every other combination falls through to the lookup and adopts whatever comes back, including the host the comment just declared invalid.

That accounts for both reports:

- #829, a US account, fails the `!= "US"` half and gets `ha-5a.prd.nar...`
- the report in #772 (region DE, API level 0) fails the `api_level == 1` half and gets `ha-5a.prd.eu...`

Two regions, one gap.

### What changed

Gate on the returned value rather than on the account. If the base URI points at `vwautocloud`, discard it and keep the static default that already works, whatever the country or API level. A usable base URI is still adopted exactly as before, and the existing shortcut for non-US API level 1 is untouched.

### Tests

`tests/test_home_region_fallback.py`, five cases: the US path, the API level 0 Europe path, a usable base URI still being adopted, a failed lookup leaving the default in place, and the existing non-US level 1 shortcut still returning early. Without the change the first two fail and the other three pass, so they pin the actual behaviour rather than the implementation. Full suite is 58 green and needs no network.

### Verification

I have no account in either affected configuration, so this rests on the two reports plus the endpoint behaviour the existing comment already documents. What the change cannot do is fix a certificate problem on the user's own side: `self-signed certificate in certificate chain` can also come from TLS interception by a router or antivirus. It removes the case where we route to a host the code already considers unusable, which is what both reporters hit.
